### PR TITLE
feat(mcp): standardize tool I/O as JSON; accept JSON string or list for spec generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,23 @@ python mcp_server.py
 
 # With UV
 uv run python mcp_server.py
+
+# Or use the helper script (uv-first)
+./run-server.sh                 # starts via `uv run`
+./run-server.sh --sync          # sync deps first
+./run-server.sh --log           # also write logs/logs/mcp_server.log
+./run-server.sh --register      # register with Claude CLI as `pr-review-spec`
+./run-server.sh --codex         # configure Codex CLI to use this server
 ```
+
+## Codex CLI Integration
+
+- Configure Codex CLI to launch this MCP via `uv`:
+  - `./run-server.sh --codex` writes an entry to `~/.codex/config.toml` under `[mcp_servers.pr-review-spec]` (or `--name <custom>`).
+  - It injects variables from `.env` into `[mcp_servers.<name>.env]`.
+  - Codex will execute: `uv run --project <repo> -- python mcp_server.py` to ensure the correct project context.
+
+To remove or change the entry, edit `~/.codex/config.toml` and adjust the `[mcp_servers.<name>]` section.
 
 The server will start and listen for requests over `stdio`, making its tools available to a connected MCP client (e.g., Claude Desktop).
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -545,7 +545,7 @@ class ReviewSpecGenerator:
                     # Fallback for legacy Python literal strings like "[{'id': 1}]"
                     try:
                         parsed = ast.literal_eval(comments)
-                    except Exception as err:
+                    except (ValueError, SyntaxError) as err:
                         raise ValueError(
                             "Invalid comments payload: not valid JSON or Python literal"
                         ) from err

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 import json
 import os
@@ -12,6 +13,7 @@ from urllib.parse import quote
 import httpx
 from dotenv import load_dotenv
 from mcp import server
+from mcp.server.lowlevel.server import NotificationOptions
 from mcp.server.models import InitializationOptions
 from mcp.types import (
     TextContent,
@@ -288,8 +290,12 @@ class ReviewSpecGenerator:
 
     def _register_handlers(self):
         """Register MCP handlers."""
-        self.server.list_tools = self.handle_list_tools
-        self.server.call_tool = self.handle_call_tool
+        # Properly register handlers with the MCP server. The low-level Server
+        # uses decorator-style registration to populate request_handlers.
+        # Direct attribute assignment does not wire up RPC methods and results
+        # in "Method not found" errors from clients.
+        self.server.list_tools()(self.handle_list_tools)
+        self.server.call_tool()(self.handle_call_tool)
 
     async def handle_list_tools(self) -> list[Tool]:
         """
@@ -485,12 +491,13 @@ class ReviewSpecGenerator:
             return [{"error": error_msg}]
 
     async def create_review_spec_file(
-        self, comments: list, filename: str | None = None
+        self, comments: list | str, filename: str | None = None
     ) -> str:
         """
         Creates a markdown file from a list of review comments.
 
-        :param comments: A list of comment objects from fetch_pr_review_comments.
+        :param comments: A list of comment objects from fetch_pr_review_comments,
+                         or a JSON/Python-literal string representing that list.
         :param filename: The name of the markdown file to create.
         :return: A success or error message.
         """
@@ -529,7 +536,38 @@ class ReviewSpecGenerator:
                     "Invalid filename: path escapes output directory"
                 ) from err
 
-            markdown_content = generate_markdown(comments)
+            # Normalize comments input to a list[dict]
+            if isinstance(comments, str):
+                parsed: object
+                try:
+                    parsed = json.loads(comments)
+                except json.JSONDecodeError:
+                    # Fallback for legacy Python literal strings like "[{'id': 1}]"
+                    try:
+                        parsed = ast.literal_eval(comments)
+                    except Exception as err:
+                        raise ValueError(
+                            "Invalid comments payload: not valid JSON or Python literal"
+                        ) from err
+
+                if isinstance(parsed, dict):
+                    comments_list: list[dict] = [parsed]
+                elif isinstance(parsed, list):
+                    comments_list = parsed  # type: ignore[assignment]
+                else:
+                    raise ValueError(
+                        "Invalid comments payload: expected a list or dict"
+                    )
+            elif isinstance(comments, list):
+                comments_list = comments
+            else:
+                raise ValueError("Invalid comments payload type")
+
+            # Validate element types
+            if not all(isinstance(c, dict) for c in comments_list):
+                raise ValueError("Invalid comments payload: items must be objects")
+
+            markdown_content = generate_markdown(comments_list)  # type: ignore[arg-type]
 
             # Perform an exclusive, no-follow create to avoid clobbering and symlinks
             async def _write_safely(path: Path, content: str) -> None:
@@ -566,13 +604,23 @@ class ReviewSpecGenerator:
             from mcp.server.stdio import stdio_server
 
             async with stdio_server() as (read_stream, write_stream):
+                notif = NotificationOptions(
+                    prompts_changed=False,
+                    resources_changed=False,
+                    tools_changed=False,
+                )
+                capabilities = self.server.get_capabilities(
+                    notif,
+                    experimental_capabilities={},
+                )
+
                 await self.server.run(
                     read_stream,
                     write_stream,
                     InitializationOptions(
                         server_name="github_review_spec_generator",
                         server_version="1.0.0",
-                        capabilities=self.server.get_capabilities(),
+                        capabilities=capabilities,
                     ),
                 )
         except Exception as e:


### PR DESCRIPTION
Summary
- Return JSON from `fetch_pr_review_comments` (via `json.dumps`) so tool output is stable and machine-parseable.
- Allow `create_review_spec_file` to accept either a JSON string or a Python list of comment dicts. Adds normalization and validation before rendering.
- Safer file writes to `review_specs/` with exclusive create + utf-8 encoding. Adds filename validation and directory containment checks.
- README: document uv-first run helper and Codex CLI integration.

Rationale
- Prior behavior returned `str(comments)` which produced a Python repr, not JSON. That was brittle for clients to parse and caused errors when the value was fed back into `create_review_spec_file`.
- Users reported: "Error executing tool create_review_spec_file: 'str' object has no attribute 'get'". This change fixes that path by both standardizing output and making input parsing robust.

Changes
- fetch flow: MCP `handle_call_tool` now returns `json.dumps(comments)` for `fetch_pr_review_comments`.
- spec flow: `create_review_spec_file(comments: list | str, ...)` will:
  - If `str`, try `json.loads`; on failure, fallback to `ast.literal_eval` to support legacy Python-repr strings.
  - Normalize `dict` -> `[dict]`; ensure items are dicts; error clearly otherwise.
  - Write to `review_specs/` using exclusive create and utf-8.
- Server registration: use low-level `server.list_tools()` / `server.call_tool()` decorators for correct RPC wiring and compute capabilities using `NotificationOptions`.
- Docs: clarify uv run script and Codex CLI integration.

Compatibility
- Not marked as breaking: `create_review_spec_file` accepts both JSON strings and lists.
- Clients of `fetch_pr_review_comments` should parse JSON (recommended). If they previously relied on Python repr, they should switch to JSON parsing.

Validation
- Ruff fix/format: clean.
- Tests: 18 passed (including pagination, input validation, and file write tests).

Security/Resilience
- Exclusive file creation prevents clobbering; no-follow mitigates symlink shenanigans.
- Filename constrained to basename with `.md` and safe charset; path containment enforced.

