### PR TITLE
feat(mcp): auto-resolve PR when pr_url omitted; dulwich-based git detection

### DIFF
--- a/git_pr_resolver.py
+++ b/git_pr_resolver.py
@@ -1,0 +1,193 @@
+import os
+import re
+import shlex
+from dataclasses import dataclass
+
+import httpx
+from dulwich import porcelain
+from dulwich.config import StackedConfig
+from dulwich.repo import Repo
+
+
+@dataclass
+class GitContext:
+    host: str
+    owner: str
+    repo: str
+    branch: str
+
+
+REMOTE_REGEXES = [
+    # SSH: git@github.com:owner/repo.git
+    re.compile(
+        r"^(?:git@)(?P<host>[^:]+):(?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$"
+    ),
+    # HTTPS: https://github.com/owner/repo(.git)
+    re.compile(
+        r"^https?://(?P<host>[^/]+)/(?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?/?$"
+    ),
+]
+
+
+def parse_remote_url(url: str) -> tuple[str, str, str]:
+    for rx in REMOTE_REGEXES:
+        m = rx.match(url)
+        if m:
+            host = m.group("host")
+            owner = m.group("owner")
+            repo = m.group("repo")
+            return host, owner, repo
+    raise ValueError(f"Unsupported remote URL: {url}")
+
+
+def _get_repo(cwd: str | None = None) -> Repo:
+    path = cwd or os.getcwd()
+    try:
+        return Repo.discover(path)
+    except Exception as e:  # noqa: BLE001
+        raise ValueError("Not a git repository (dulwich discover failed)") from e
+
+
+def git_detect_repo_branch(cwd: str | None = None) -> GitContext:
+    # Env overrides are useful in CI/agents
+    env_owner = os.getenv("MCP_PR_OWNER")
+    env_repo = os.getenv("MCP_PR_REPO")
+    env_branch = os.getenv("MCP_PR_BRANCH")
+    if env_owner and env_repo and env_branch:
+        host = os.getenv("GH_HOST", "github.com")
+        return GitContext(host=host, owner=env_owner, repo=env_repo, branch=env_branch)
+
+    # Discover via dulwich when not overridden
+    repo_obj = _get_repo(cwd)
+
+    # Remote URL: prefer 'origin'
+    cfg: StackedConfig = repo_obj.get_config()
+    remote_url_b: bytes | None = None
+    try:
+        remote_url_b = cfg.get((b"remote", b"origin"), b"url")
+    except KeyError:
+        # Fallback: first remote
+        for sect in cfg.sections():
+            if sect and sect[0] == b"remote" and len(sect) > 1:
+                try:
+                    remote_url_b = cfg.get(sect, b"url")
+                    break
+                except KeyError:
+                    continue
+    if not remote_url_b:
+        raise ValueError("No git remote configured")
+    remote_url = remote_url_b.decode("utf-8", errors="ignore")
+    host, owner, repo = parse_remote_url(remote_url)
+
+    # Current branch
+    head_ref = repo_obj.refs.read_ref(b"HEAD")
+    branch = None
+    if head_ref and head_ref.startswith(b"refs/heads/"):
+        branch = head_ref.split(b"/", 2)[-1].decode("utf-8", errors="ignore")
+    else:
+        # Detached HEAD: attempt porcelain.active_branch
+        try:
+            branch = porcelain.active_branch(repo_obj).decode("utf-8", errors="ignore")
+        except Exception as _e:  # noqa: BLE001
+            branch = None
+    if not branch:
+        raise ValueError("Unable to determine current branch")
+
+    return GitContext(host=host, owner=owner, repo=repo, branch=branch)
+
+
+def api_base_for_host(host: str) -> str:
+    # Explicit override takes precedence (e.g., GHES custom URL)
+    explicit = os.getenv("GITHUB_API_URL")
+    if explicit:
+        return explicit.rstrip("/")
+    if host.lower() == "github.com":
+        return "https://api.github.com"
+    # GitHub Enterprise default pattern
+    return f"https://{host}/api/v3"
+
+
+async def resolve_pr_url(
+    owner: str,
+    repo: str,
+    branch: str | None = None,
+    *,
+    select_strategy: str = "branch",
+    host: str | None = None,
+    token: str | None = None,
+) -> str:
+    """Resolve a PR HTML URL for an open PR.
+
+    Strategies:
+      - branch: pick PR with head.ref == branch; error if none
+      - latest: most recently updated open PR
+      - first: numerically smallest PR among open PRs
+      - error: require exact branch match only
+    """
+    if select_strategy not in {"branch", "latest", "first", "error"}:
+        raise ValueError("Invalid select_strategy")
+
+    api_base = api_base_for_host(host or os.getenv("GH_HOST", "github.com"))
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "mcp-pr-review-spec-maker/1.0",
+    }
+    token = token or os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    timeout = httpx.Timeout(timeout=20.0, connect=10.0)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        pr_candidates = []
+        # Prefer branch match first when strategy allows
+        if branch and select_strategy in {"branch", "error"}:
+            # Use owner as the source namespace for head
+            head_param = f"{owner}:{branch}"
+            url = (
+                f"{api_base}/repos/{owner}/{repo}/pulls"
+                f"?state=open&head={shlex.quote(head_param)}"
+            )
+            r = await client.get(url, headers=headers)
+            # If unauthorized or rate-limited, surface as a clear error
+            r.raise_for_status()
+            data = r.json()
+            if data:
+                pr = data[0]
+                return pr.get("html_url") or pr.get("url")
+            if select_strategy == "error":
+                raise ValueError(
+                    f"No open PR found for branch '{branch}' in {owner}/{repo}"
+                )
+
+        # Fallback list of open PRs
+        url = (
+            f"{api_base}/repos/{owner}/{repo}/pulls"
+            "?state=open&sort=updated&direction=desc"
+        )
+        r = await client.get(url, headers=headers)
+        r.raise_for_status()
+        pr_candidates = r.json() or []
+
+        if not pr_candidates:
+            raise ValueError(f"No open PRs found for {owner}/{repo}")
+
+        if select_strategy == "branch" and branch:
+            for pr in pr_candidates:
+                if pr.get("head", {}).get("ref") == branch:
+                    return pr.get("html_url") or pr.get("url")
+            raise ValueError(
+                f"No open PR found for branch '{branch}' in {owner}/{repo}"
+            )
+
+        if select_strategy == "latest":
+            pr = pr_candidates[0]
+            return pr.get("html_url") or pr.get("url")
+
+        if select_strategy == "first":
+            # Choose numerically smallest PR number
+            pr = min(pr_candidates, key=lambda p: int(p.get("number", 1 << 30)))
+            return pr.get("html_url") or pr.get("url")
+
+        # Default safety
+        pr = pr_candidates[0]
+        return pr.get("html_url") or pr.get("url")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -20,6 +20,8 @@ from mcp.types import (
     Tool,
 )
 
+from git_pr_resolver import git_detect_repo_branch, resolve_pr_url
+
 # Load environment variables
 load_dotenv()
 
@@ -98,7 +100,7 @@ async def fetch_pr_comments(
 
     try:
         timeout = httpx.Timeout(timeout=30.0, connect=10.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             used_token_fallback = False
             while url:
                 print(f"Fetching page {page_count + 1}...", file=sys.stderr)
@@ -306,13 +308,39 @@ class ReviewSpecGenerator:
         return [
             Tool(
                 name="fetch_pr_review_comments",
-                description="Fetches all review comments from a GitHub PR URL",
+                description=(
+                    "Fetches all review comments from a GitHub PR. Provide a PR URL, "
+                    "or omit it to auto-detect from the current git repo/branch."
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
                         "pr_url": {
                             "type": "string",
-                            "description": "The full URL of the GitHub pull request",
+                            "description": (
+                                "The full URL of the GitHub pull request. If omitted, "
+                                "the server will try to resolve the PR for the current "
+                                "git repo and branch."
+                            ),
+                        },
+                        "select_strategy": {
+                            "type": "string",
+                            "enum": ["branch", "latest", "first", "error"],
+                            "description": (
+                                "Strategy when auto-resolving a PR (default 'branch')."
+                            ),
+                        },
+                        "owner": {
+                            "type": "string",
+                            "description": "Override repo owner for PR resolution",
+                        },
+                        "repo": {
+                            "type": "string",
+                            "description": "Override repo name for PR resolution",
+                        },
+                        "branch": {
+                            "type": "string",
+                            "description": "Override branch name for PR resolution",
                         },
                         "per_page": {
                             "type": "integer",
@@ -422,11 +450,15 @@ class ReviewSpecGenerator:
                 )
 
                 comments = await self.fetch_pr_review_comments(
-                    arguments["pr_url"],
+                    arguments.get("pr_url", ""),
                     per_page=per_page,
                     max_pages=max_pages,
                     max_comments=max_comments,
                     max_retries=max_retries,
+                    select_strategy=arguments.get("select_strategy"),
+                    owner=arguments.get("owner"),
+                    repo=arguments.get("repo"),
+                    branch=arguments.get("branch"),
                 )
                 return [TextContent(type="text", text=json.dumps(comments))]
 
@@ -454,12 +486,16 @@ class ReviewSpecGenerator:
 
     async def fetch_pr_review_comments(
         self,
-        pr_url: str,
+        pr_url: str | None,
         *,
         per_page: int | None = None,
         max_pages: int | None = None,
         max_comments: int | None = None,
         max_retries: int | None = None,
+        select_strategy: str | None = None,
+        owner: str | None = None,
+        repo: str | None = None,
+        branch: str | None = None,
     ) -> list:
         """
         Fetches all review comments from a GitHub pull request URL.
@@ -472,6 +508,24 @@ class ReviewSpecGenerator:
             file=sys.stderr,
         )
         try:
+            # If URL not provided, attempt auto-resolution via git + GitHub
+            if not pr_url:
+                # Use explicit overrides if provided; otherwise detect
+                if not (owner and repo and branch):
+                    ctx = git_detect_repo_branch()
+                    owner = owner or ctx.owner
+                    repo = repo or ctx.repo
+                    branch = branch or ctx.branch
+                strategy = select_strategy or "branch"
+                resolved_url = await resolve_pr_url(
+                    owner=owner or "",
+                    repo=repo or "",
+                    branch=branch,
+                    select_strategy=strategy,
+                    host=None,
+                )
+                pr_url = resolved_url
+
             owner, repo, pull_number_str = get_pr_info(pr_url)
             pull_number = int(pull_number_str)
             comments = await fetch_pr_comments(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "mcp>=1.4.0",
     "httpx>=0.27.0",
     "aiofiles>=23.2.1",
+    "dulwich>=0.22.0",
 ]
 
 [project.optional-dependencies]

--- a/run-server.sh
+++ b/run-server.sh
@@ -1,0 +1,673 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# PR Review Spec MCP Server Setup Script
+#
+# A platform-agnostic setup script modeled after zen's run-server.sh. Handles
+# environment setup, dependency installation (uv and fallback venv), CLI/desktop
+# registration for Claude, Codex, and Gemini, optional Docker cleanup, and run.
+# ============================================================================
+
+# Initialize pyenv early if present
+if [[ -d "$HOME/.pyenv" ]]; then
+  export PYENV_ROOT="$HOME/.pyenv"
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  if command -v pyenv &>/dev/null; then
+    eval "$(pyenv init --path)" 2>/dev/null || true
+    eval "$(pyenv init -)" 2>/dev/null || true
+  fi
+fi
+
+# ----------------------------------------------------------------------------
+# Constants and configuration
+# ----------------------------------------------------------------------------
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+VENV_PATH=".pr_review_venv"
+DOCKER_CLEANED_FLAG=".docker_cleaned"
+DESKTOP_CONFIG_FLAG=".desktop_configured"
+LOG_DIR="$SCRIPT_DIR/logs"
+LOG_FILE="mcp_server.log"
+ENV_FILE=".env"
+SERVER_NAME="pr-review-spec"
+
+# Flags
+DO_SYNC="false"           # dependency sync/install
+USE_DEV="false"           # include dev deps
+DO_LOG="false"            # write logs
+DO_REGISTER="false"       # Claude CLI
+DO_DESKTOP="false"        # Claude Desktop
+DO_CODEX="false"          # Codex CLI
+DO_GEMINI="false"         # Gemini CLI
+DO_MIGRATE_ENV="false"    # host.docker.internal -> localhost
+ASSUME_YES="false"        # auto-approve prompts
+DO_DRYRUN="false"         # print instructions only
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+ok() { echo -e "${GREEN}✓${NC} $*" >&2; }
+warn() { echo -e "${YELLOW}!${NC} $*" >&2; }
+err() { echo -e "${RED}✗${NC} $*" >&2; }
+info() { echo -e "${YELLOW}$*${NC}" >&2; }
+
+get_script_dir() { cd "$(dirname "$0")" && pwd; }
+
+prompt_yes() {
+  # Usage: prompt_yes "Question? (Y/n): "
+  local q="$1"
+  if [[ "$ASSUME_YES" == "true" ]]; then return 0; fi
+  if [[ ! -t 0 ]]; then return 1; fi
+  read -p "$q" -n 1 -r; echo ""
+  [[ ! $REPLY =~ ^[Nn]$ ]]
+}
+
+clear_python_cache() {
+  info "Clearing Python cache files..."
+  find . -name "*.pyc" -delete 2>/dev/null || true
+  find . -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
+  ok "Python cache cleared"
+}
+
+detect_os() {
+  case "$OSTYPE" in
+    darwin*) echo "macos" ;;
+    linux*)
+      if grep -qi microsoft /proc/version 2>/dev/null; then echo "wsl"; else echo "linux"; fi ;;
+    msys*|cygwin*|win32) echo "windows" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+get_claude_config_path() {
+  local os_type=$(detect_os)
+  case "$os_type" in
+    macos) echo "$HOME/Library/Application Support/Claude/claude_desktop_config.json" ;;
+    linux) echo "$HOME/.config/Claude/claude_desktop_config.json" ;;
+    wsl)
+      if command -v wslvar &>/dev/null; then
+        local win_appdata=$(wslvar APPDATA 2>/dev/null || true)
+        [[ -n "$win_appdata" ]] && echo "$(wslpath "$win_appdata")/Claude/claude_desktop_config.json" && return
+      fi
+      echo "/mnt/c/Users/$USER/AppData/Roaming/Claude/claude_desktop_config.json" ;;
+    windows) echo "$APPDATA/Claude/claude_desktop_config.json" ;;
+    *) echo "" ;;
+  esac
+}
+
+# ----------------------------------------------------------------------------
+# Docker cleanup (one-time)
+# ----------------------------------------------------------------------------
+cleanup_docker() {
+  [[ -f "$DOCKER_CLEANED_FLAG" ]] && return 0
+  if ! command -v docker &>/dev/null || ! docker info &>/dev/null 2>&1; then
+    return 0
+  fi
+  local found=false
+  local containers=(
+    "gemini-mcp-server" "gemini-mcp-redis"
+    "zen-mcp-server" "zen-mcp-redis" "zen-mcp-log-monitor"
+  )
+  for c in "${containers[@]}"; do
+    if docker ps -a --format "{{.Names}}" | grep -q "^${c}$" 2>/dev/null; then
+      [[ "$found" == false ]] && echo "One-time Docker cleanup..." && found=true
+      docker stop "$c" >/dev/null 2>&1 || true
+      docker rm "$c" >/dev/null 2>&1 || true
+    fi
+  done
+  local images=("gemini-mcp-server:latest" "zen-mcp-server:latest")
+  for i in "${images[@]}"; do
+    if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "^${i}$" 2>/dev/null; then
+      [[ "$found" == false ]] && echo "One-time Docker cleanup..." && found=true
+      docker rmi "$i" >/dev/null 2>&1 || true
+    fi
+  done
+  local volumes=("redis_data" "mcp_logs")
+  for v in "${volumes[@]}"; do
+    if docker volume ls --format "{{.Name}}" | grep -q "^${v}$" 2>/dev/null; then
+      [[ "$found" == false ]] && echo "One-time Docker cleanup..." && found=true
+      docker volume rm "$v" >/dev/null 2>&1 || true
+    fi
+  done
+  [[ "$found" == true ]] && ok "Docker cleanup complete"
+  touch "$DOCKER_CLEANED_FLAG"
+}
+
+# ----------------------------------------------------------------------------
+# Python/venv bootstrap
+# ----------------------------------------------------------------------------
+get_venv_python_path() {
+  local venv_path="$1"
+  local abs=$(cd "$(dirname "$venv_path")" && pwd)/"$(basename "$venv_path")"
+  if [[ -f "$abs/bin/python" ]]; then echo "$abs/bin/python"; return 0; fi
+  if [[ -f "$abs/Scripts/python.exe" ]]; then echo "$abs/Scripts/python.exe"; return 0; fi
+  return 1
+}
+
+detect_linux_distro() {
+  if [[ -f /etc/os-release ]]; then . /etc/os-release; echo "${ID:-unknown}"; return; fi
+  [[ -f /etc/debian_version ]] && echo "debian" && return
+  [[ -f /etc/redhat-release ]] && echo "rhel" && return
+  [[ -f /etc/arch-release ]] && echo "arch" && return
+  echo "unknown"
+}
+
+get_install_command() {
+  local distro="$1"; local python_version="${2:-}"
+  local ver=""; [[ "$python_version" =~ ([0-9]+\.[0-9]+) ]] && ver="${BASH_REMATCH[1]}"
+  case "$distro" in
+    ubuntu|debian|raspbian|pop|linuxmint|elementary)
+      if [[ -n "$ver" ]]; then
+        echo "sudo apt update && (sudo apt install -y python${ver}-venv python${ver}-dev || sudo apt install -y python3-venv python3-pip)"; else echo "sudo apt update && sudo apt install -y python3-venv python3-pip"; fi ;;
+    fedora) echo "sudo dnf install -y python3-venv python3-pip" ;;
+    rhel|centos|rocky|almalinux|oracle) echo "sudo dnf install -y python3-venv python3-pip || sudo yum install -y python3-venv python3-pip" ;;
+    arch|manjaro|endeavouros) echo "sudo pacman -Syu --noconfirm python-pip python-virtualenv" ;;
+    opensuse|suse) echo "sudo zypper install -y python3-venv python3-pip" ;;
+    alpine) echo "sudo apk add --no-cache python3-dev py3-pip py3-virtualenv" ;;
+    *) echo "" ;;
+  esac
+}
+
+can_use_sudo() {
+  command -v sudo &>/dev/null || return 1
+  sudo -n true 2>/dev/null && return 0
+  [[ -t 0 ]] && sudo true 2>/dev/null && return 0
+  return 1
+}
+
+try_install_system_packages() {
+  local python_cmd="${1:-python3}"
+  local os=$(detect_os)
+  [[ "$os" == "linux" || "$os" == "wsl" ]] || return 1
+  local ver=$($python_cmd --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+  local distro=$(detect_linux_distro)
+  local cmd=$(get_install_command "$distro" "$ver")
+  [[ -z "$cmd" ]] && return 1
+  info "Attempting to install required Python packages..."
+  if can_use_sudo; then
+    info "Installing system packages (may ask for password)..."
+    bash -c "$cmd" >/dev/null 2>&1 && { ok "System packages installed"; return 0; }
+  fi
+  return 1
+}
+
+bootstrap_pip() {
+  local vpython="$1"
+  info "Bootstrapping pip in virtual environment..."
+  if $vpython -m ensurepip --default-pip >/dev/null 2>&1; then ok "pip bootstrapped"; return 0; fi
+  local url="https://bootstrap.pypa.io/get-pip.py"; local tmp=$(mktemp)
+  if command -v curl &>/dev/null; then curl -fsSL "$url" -o "$tmp" || true; else wget -q "$url" -O "$tmp" || true; fi
+  if [[ -s "$tmp" ]]; then $vpython "$tmp" >/dev/null 2>&1 && ok "pip installed"; fi
+  rm -f "$tmp" || true
+}
+
+create_or_activate_virtualenv() {
+  # Prefer uv if present and project is configured
+  if command -v uv &>/dev/null; then
+    # Ensure uv has a venv, otherwise fallback to system python virtualenv
+    # We'll still resolve python path for CLI registrations
+    local uv_py
+    uv_py=$(uv run which python 2>/dev/null || true)
+    if [[ -n "$uv_py" ]]; then echo "$uv_py"; return 0; fi
+  fi
+
+  # If already inside venv, prefer that
+  if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+    ok "Using activated virtual environment"
+    echo "$(command -v python)"; return 0
+  fi
+
+  local python_cmd=""
+  # Prefer pyenv local if present
+  if [[ -f .python-version && $(command -v pyenv) ]]; then pyenv local &>/dev/null || true; fi
+  for c in python3.12 python3.13 python3.11 python3 python; do
+    if command -v "$c" &>/dev/null; then python_cmd="$c"; break; fi
+  done
+  if [[ -z "$python_cmd" ]]; then err "No Python found (3.10+ required)"; exit 1; fi
+
+  # Create venv if missing
+  if [[ ! -d "$VENV_PATH" ]]; then
+    info "Creating virtual environment at $VENV_PATH..."
+    if ! $python_cmd -m venv "$VENV_PATH" 2>/dev/null; then
+      local err_out=$($python_cmd -m venv "$VENV_PATH" 2>&1 || true)
+      if echo "$err_out" | grep -E -q "No module named venv|ensurepip|python3.*-venv"; then
+        try_install_system_packages "$python_cmd" && $python_cmd -m venv "$VENV_PATH" >/dev/null 2>&1 || true
+      fi
+      if [[ ! -d "$VENV_PATH" ]]; then
+        if command -v virtualenv &>/dev/null; then virtualenv -p "$python_cmd" "$VENV_PATH" >/dev/null 2>&1 || true; fi
+      fi
+      [[ -d "$VENV_PATH" ]] || { err "Unable to create virtual environment"; exit 1; }
+    fi
+    ok "Virtual environment created"
+  fi
+
+  local vpython
+  vpython=$(get_venv_python_path "$VENV_PATH") || { err "Venv Python not found"; exit 1; }
+  # Ensure pip exists
+  if ! $vpython -m pip --version >/dev/null 2>&1; then bootstrap_pip "$vpython" || true; fi
+  if ! $vpython -m pip --version >/dev/null 2>&1; then err "pip unavailable in venv"; exit 1; fi
+  echo "$vpython"
+}
+
+install_dependencies() {
+  local vpython="$1"
+  info "Installing dependencies..."
+  if command -v uv >/dev/null 2>&1; then
+    if [[ "$USE_DEV" == "true" ]]; then uv sync --dev >/dev/null; else uv sync >/dev/null; fi
+  else
+    local has_req=false
+    if [[ -f requirements.txt ]]; then has_req=true; "$vpython" -m pip install -r requirements.txt >/dev/null; fi
+    if [[ "$USE_DEV" == "true" && -f requirements-dev.txt ]]; then "$vpython" -m pip install -r requirements-dev.txt >/dev/null; fi
+    if [[ "$has_req" == false && -f pyproject.toml ]]; then "$vpython" -m pip install -e . >/dev/null; fi
+  fi
+  ok "Dependencies installed"
+}
+
+# ----------------------------------------------------------------------------
+# Env handling
+# ----------------------------------------------------------------------------
+read_env_vars() {
+  local file="$1"; [[ -f "$file" ]] || return 0
+  grep -E '^[[:space:]]*[^#][^=]*=.*$' "$file" | sed 's/^[[:space:]]*//' || true
+}
+
+prepare_env_file() {
+  if [[ -f "$ENV_FILE" ]]; then return 0; fi
+  info "No $ENV_FILE found. Server will still run; set GITHUB_TOKEN for GitHub API access."
+  if [[ -f .env.example ]]; then
+    if prompt_yes "Create .env from .env.example? (Y/n): "; then
+      cp .env.example "$ENV_FILE"
+      ok "Created $ENV_FILE from example"
+    else
+      info "Skipping .env creation"
+    fi
+  fi
+}
+
+migrate_env_file() {
+  [[ -f "$ENV_FILE" ]] || return 0
+  if grep -q 'host\.docker\.internal' "$ENV_FILE"; then
+    info "Migrating Docker hostnames in $ENV_FILE..."
+    if sed --version >/dev/null 2>&1; then sed -i 's/host\.docker\.internal/localhost/g' "$ENV_FILE"; else sed -i '' 's/host\.docker\.internal/localhost/g' "$ENV_FILE"; fi
+    ok "Migrated .env"
+  fi
+}
+
+maybe_migrate_env_file() {
+  [[ -f "$ENV_FILE" ]] || return 0
+  if grep -q 'host\.docker\.internal' "$ENV_FILE"; then
+    if prompt_yes "Replace host.docker.internal with localhost in $ENV_FILE? (Y/n): "; then
+      migrate_env_file
+    fi
+  fi
+}
+
+check_api_keys() {
+  local token_val=$(grep -E '^GITHUB_TOKEN=' "$ENV_FILE" 2>/dev/null | sed 's/^GITHUB_TOKEN=//')
+  if [[ -n "${GITHUB_TOKEN:-}" && "${GITHUB_TOKEN}" != "your_github_token_here" ]]; then ok "GITHUB_TOKEN configured (env)"; return; fi
+  if [[ -n "$token_val" && "$token_val" != "your_github_token_here" ]]; then ok "GITHUB_TOKEN configured (.env)"; return; fi
+  warn "No GITHUB_TOKEN found; GitHub API may rate limit."
+}
+
+parse_env_variables() {
+  local vars=""; [[ -f "$ENV_FILE" ]] || { echo "$vars"; return; }
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    if [[ "$line" =~ ^[[:space:]]*([^=]+)=(.*)$ ]]; then
+      local k="${BASH_REMATCH[1]}"; local v="${BASH_REMATCH[2]}"
+      k=$(echo "$k" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      v=$(echo "$v" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed 's/^"//;s/"$//')
+      v=$(echo "$v" | sed 's/[[:space:]]*#.*$//')
+      [[ -n "$v" && ! "$v" =~ ^your_.*_here$ && ! "$v" =~ ^[[:space:]]*$ ]] && vars+="$k=$v"$'\n'
+    fi
+  done < "$ENV_FILE"
+  echo "$vars"
+}
+
+# ----------------------------------------------------------------------------
+# Claude/Codex/Gemini integrations
+# ----------------------------------------------------------------------------
+build_claude_env_args() {
+  local out=""; local env_vars=$(parse_env_variables)
+  if [[ -n "$env_vars" ]]; then
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then out+=" -e ${BASH_REMATCH[1]}=\"${BASH_REMATCH[2]}\""; fi
+    done <<< "$env_vars"
+  fi
+  echo "$out"
+}
+
+check_claude_cli_integration() {
+  local vpython="$1"; local server_path="$2"
+  if ! command -v claude &>/dev/null; then
+    if [[ "$DO_REGISTER" == "true" ]]; then
+      warn "Claude CLI not found. Install from: https://docs.anthropic.com/claude/docs/claude-code-cli"
+    else
+      info "Claude CLI not found; skipping registration"
+    fi
+    return 0
+  fi
+  info "Configuring Claude CLI ($SERVER_NAME)..."
+  local env_args=$(build_claude_env_args)
+  claude mcp remove "$SERVER_NAME" -s user >/dev/null 2>&1 || true
+  local cmd="claude mcp add '$SERVER_NAME' -s user$env_args -- '$vpython' '$server_path'"
+  if eval "$cmd" >/dev/null 2>&1; then ok "Claude CLI configured ($SERVER_NAME)"; else warn "Claude CLI registration failed"; fi
+}
+
+configure_claude_desktop() {
+  local vpython="$1"; local server_path="$2"
+  local cfg_path=$(get_claude_config_path); [[ -z "$cfg_path" ]] && return 0
+  mkdir -p "$(dirname "$cfg_path")" 2>/dev/null || true
+  local env_vars=$(parse_env_variables)
+  local tmp=$(mktemp); local env_file=$(mktemp)
+  [[ -n "$env_vars" ]] && echo "$env_vars" > "$env_file"
+  python - "$cfg_path" "$vpython" "$server_path" "$env_file" << 'PY'
+import json, sys, os
+cfg_path, py, srv, env_file = sys.argv[1:5]
+env = {}
+try:
+  with open(env_file) as f:
+    for line in f:
+      line=line.strip()
+      if '=' in line and line:
+        k,v=line.split('=',1)
+        env[k]=v
+except: pass
+cfg={'mcpServers':{}}
+if os.path.exists(cfg_path):
+  try:
+    with open(cfg_path) as f: cfg=json.load(f) or cfg
+  except Exception: pass
+m=cfg.setdefault('mcpServers',{})
+name=os.environ.get('SERVER_NAME','pr-review-spec')
+entry={'command': py, 'args':[srv]}
+if env: entry['env']=env
+m[name]=entry
+with open(cfg_path,'w') as f: json.dump(cfg,f,indent=2)
+print(cfg_path)
+PY
+  rm -f "$tmp" "$env_file" 2>/dev/null || true
+  ok "Claude Desktop configured at $cfg_path"
+}
+
+check_codex_cli_integration() {
+  local vpython="$1"; local server_path="$2"
+  if ! command -v codex &>/dev/null; then
+    info "Codex CLI not found; skipping configuration"
+    return 0
+  fi
+  local cfg="$HOME/.codex/config.toml"
+  mkdir -p "$(dirname "$cfg")" 2>/dev/null || true
+  local env_vars=$(parse_env_variables)
+  {
+    echo ""; echo "[mcp_servers.$SERVER_NAME]"; echo "command = \"$vpython\""; echo "args = [\"$server_path\"]"; echo ""; echo "[mcp_servers.$SERVER_NAME.env]"; echo "PATH = \"/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$HOME/bin\"";
+    if [[ -n "$env_vars" ]]; then
+      while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
+          local key="${BASH_REMATCH[1]}"; local value="${BASH_REMATCH[2]}"
+          value=$(echo "$value" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+          echo "$key = \"$value\""
+        fi
+      done <<< "$env_vars"
+    fi
+  } >> "$cfg"
+  ok "Codex CLI configured at $cfg ($SERVER_NAME)"
+}
+
+configure_gemini_cli() {
+  local vpython="$1"; local server_path="$2"
+  if [[ -z "${HOME:-}" ]]; then return 0; fi
+  local gemini_cfg="$HOME/.gemini/settings.json"
+  mkdir -p "$(dirname "$gemini_cfg")" 2>/dev/null || true
+  python - "$gemini_cfg" "$vpython" "$server_path" << 'PY'
+import json, os, sys
+cfg_path, py, srv = sys.argv[1:4]
+cfg = {}
+if os.path.exists(cfg_path):
+  try:
+    with open(cfg_path) as f: cfg=json.load(f) or {}
+  except Exception: cfg={}
+m = cfg.setdefault('mcpServers', {})
+name = os.environ.get('SERVER_NAME','pr-review-spec')
+m[name] = {'command': py, 'args': [srv]}
+with open(cfg_path,'w') as f: json.dump(cfg,f,indent=2)
+print(cfg_path)
+PY
+  ok "Gemini CLI configured"
+}
+
+# ----------------------------------------------------------------------------
+# Display configuration instructions (Claude CLI, Desktop, Gemini, Codex)
+# ----------------------------------------------------------------------------
+display_config_instructions() {
+  local python_cmd="$1"; local server_path="$2"; local script_dir=$(dirname "$server_path")
+  echo ""
+  local header="PR REVIEW SPEC MCP SERVER CONFIGURATION"
+  echo "===== $header ====="
+  printf '%*s\n' "$((${#header} + 12))" | tr ' ' '='
+  echo ""
+
+  info "1. Claude Code (CLI)"
+  local env_vars=$(parse_env_variables)
+  local env_args=""
+  if [[ -n "$env_vars" ]]; then
+    while IFS= read -r line; do
+      if [[ -n "$line" && "$line" =~ ^([^=]+)=(.*)$ ]]; then
+        env_args+=" -e ${BASH_REMATCH[1]}=\"${BASH_REMATCH[2]}\""
+      fi
+    done <<< "$env_vars"
+  fi
+  echo -e "   ${GREEN}claude mcp add $SERVER_NAME -s user$env_args -- $python_cmd $server_path${NC}"
+  echo ""
+
+  info "2. Claude Desktop"
+  echo "   Add this to your Claude Desktop config file:"
+  echo ""
+  local example_env=""
+  if [[ -n "$env_vars" ]]; then
+    local first_entry=true
+    while IFS= read -r line; do
+      if [[ -n "$line" && "$line" =~ ^([^=]+)=(.*)$ ]]; then
+        local key="${BASH_REMATCH[1]}"
+        local value="your_$(echo "${key}" | tr '[:upper:]' '[:lower:]')"
+        if [[ "$first_entry" == true ]]; then
+          first_entry=false
+          example_env="         \"$key\": \"$value\""
+        else
+          example_env+=",\n         \"$key\": \"$value\""
+        fi
+      fi
+    done <<< "$env_vars"
+  fi
+  cat << EOF
+   {
+     "mcpServers": {
+       "$SERVER_NAME": {
+         "command": "$python_cmd",
+         "args": ["$server_path"]$(if [[ -n "$example_env" ]]; then echo ","; fi)$(if [[ -n "$example_env" ]]; then echo "
+         \"env\": {
+$(echo -e "$example_env")
+         }"; fi)
+       }
+     }
+   }
+EOF
+  local config_path=$(get_claude_config_path)
+  if [[ -n "$config_path" ]]; then
+    echo ""
+    info "   Config file location:"
+    echo -e "   ${YELLOW}$config_path${NC}"
+  fi
+  echo ""
+  info "   Restart Claude Desktop after updating the file"
+  echo ""
+
+  info "3. Gemini CLI"
+  echo "   Add this to ~/.gemini/settings.json:"
+  cat << EOF
+   {
+     "mcpServers": {
+       "$SERVER_NAME": {
+         "command": "$python_cmd",
+         "args": ["$server_path"]
+       }
+     }
+   }
+EOF
+  echo ""
+
+  info "4. Codex CLI"
+  echo "   Add this to ~/.codex/config.toml:"
+  cat << EOF
+   [mcp_servers.$SERVER_NAME]
+   command = "$python_cmd"
+   args = ["$server_path"]
+
+   [mcp_servers.$SERVER_NAME.env]
+   PATH = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$HOME/bin"
+EOF
+  if [[ -n "$env_vars" ]]; then
+    while IFS= read -r line; do
+      if [[ -n "$line" && "$line" =~ ^([^=]+)=(.*)$ ]]; then
+        local key="${BASH_REMATCH[1]}"
+        echo "   ${key} = \"your_$(echo "${key}" | tr '[:upper:]' '[:lower:]')\""
+      fi
+    done <<< "$env_vars"
+  else
+    echo "   GITHUB_TOKEN = \"your_github_token_here\""
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------------
+usage() {
+  cat >&2 <<EOF
+Usage: ./run-server.sh [options]
+
+Options:
+  --sync             Install deps (requirements/pyproject)
+  --dev              Include dev deps when installing
+  --log              Tee output to logs/$LOG_FILE
+  --env FILE         Path to .env (default: .env)
+  --name NAME        Server name for CLI/desktop (default: pr-review-spec)
+  --register         Register with Claude CLI
+  --desktop          Configure Claude Desktop
+  --codex            Configure Codex CLI
+  --gemini           Configure Gemini CLI
+  --migrate-env      Replace host.docker.internal -> localhost in .env
+  --dry-run          Only print configuration instructions; do not run
+  --yes              Auto-approve interactive prompts
+  -h, --help         Show help and exit
+
+Examples:
+  ./run-server.sh --sync --dev
+  ./run-server.sh --register --desktop --codex --gemini
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --sync) DO_SYNC="true"; shift ;;
+      --dev) USE_DEV="true"; shift ;;
+      --log) DO_LOG="true"; shift ;;
+      --env) ENV_FILE="$2"; shift 2 ;;
+      --name) SERVER_NAME="$2"; shift 2 ;;
+      --register) DO_REGISTER="true"; shift ;;
+      --desktop) DO_DESKTOP="true"; shift ;;
+      --codex) DO_CODEX="true"; shift ;;
+      --gemini) DO_GEMINI="true"; shift ;;
+      --migrate-env) DO_MIGRATE_ENV="true"; shift ;;
+      --dry-run) DO_DRYRUN="true"; shift ;;
+      --yes) ASSUME_YES="true"; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) err "Unknown option: $1"; usage; exit 1 ;;
+    esac
+  done
+}
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+parse_args "$@"
+
+mkdir -p "$LOG_DIR"
+
+clear_python_cache
+cleanup_docker || true
+
+prepare_env_file
+if [[ "$DO_MIGRATE_ENV" == "true" ]]; then
+  migrate_env_file
+else
+  maybe_migrate_env_file
+fi
+check_api_keys || true
+
+if [[ "$DO_DRYRUN" == "true" ]]; then
+  # Dry-run: print configuration instructions without mutating state
+  DRY_PY="python"
+  if command -v python3 >/dev/null 2>&1; then DRY_PY="python3"; fi
+  display_config_instructions "$DRY_PY" "$SCRIPT_DIR/mcp_server.py" || true
+  exit 0
+fi
+
+VPY=$(create_or_activate_virtualenv)
+[[ "$DO_SYNC" == "true" ]] && install_dependencies "$VPY"
+
+# Track whether we configured any client to avoid redundant banner
+DID_REGISTER=false
+DID_DESKTOP=false
+DID_CODEX=false
+DID_GEMINI=false
+
+if [[ "$DO_REGISTER" == "true" ]]; then
+  check_claude_cli_integration "$VPY" "$SCRIPT_DIR/mcp_server.py" && DID_REGISTER=true
+elif prompt_yes "Register with Claude CLI? (Y/n): "; then
+  check_claude_cli_integration "$VPY" "$SCRIPT_DIR/mcp_server.py" && DID_REGISTER=true
+fi
+if [[ "$DO_DESKTOP" == "true" ]]; then
+  SERVER_NAME="$SERVER_NAME" configure_claude_desktop "$VPY" "$SCRIPT_DIR/mcp_server.py" && DID_DESKTOP=true
+elif prompt_yes "Configure Claude Desktop? (Y/n): "; then
+  SERVER_NAME="$SERVER_NAME" configure_claude_desktop "$VPY" "$SCRIPT_DIR/mcp_server.py" && DID_DESKTOP=true
+fi
+if [[ "$DO_CODEX" == "true" ]]; then
+  check_codex_cli_integration "$VPY" "$SCRIPT_DIR/mcp_server.py" && DID_CODEX=true
+elif prompt_yes "Configure Codex CLI? (Y/n): "; then
+  check_codex_cli_integration "$VPY" "$SCRIPT_DIR/mcp_server.py" && DID_CODEX=true
+fi
+if [[ "$DO_GEMINI" == "true" ]]; then
+  configure_gemini_cli "$VPY" "$SCRIPT_DIR/mcp_server.py" && DID_GEMINI=true
+elif prompt_yes "Configure Gemini CLI? (Y/n): "; then
+  configure_gemini_cli "$VPY" "$SCRIPT_DIR/mcp_server.py" && DID_GEMINI=true
+fi
+
+info "Starting MCP server..."
+export PYTHONUNBUFFERED=1
+if command -v uv >/dev/null 2>&1; then
+  if [[ "$DO_LOG" == "true" ]]; then
+    echo "--- $(date) ---" >> "$LOG_DIR/$LOG_FILE"
+    uv run -- python "$SCRIPT_DIR/mcp_server.py" 2>&1 | tee -a "$LOG_DIR/$LOG_FILE"
+  else
+    exec uv run -- python "$SCRIPT_DIR/mcp_server.py"
+  fi
+else
+  if [[ "$DO_LOG" == "true" ]]; then
+    echo "--- $(date) ---" >> "$LOG_DIR/$LOG_FILE"
+    "$VPY" "$SCRIPT_DIR/mcp_server.py" 2>&1 | tee -a "$LOG_DIR/$LOG_FILE"
+  else
+    "$VPY" "$SCRIPT_DIR/mcp_server.py"
+  fi
+fi
+
+if [[ "$DID_REGISTER" == "false" && "$DID_DESKTOP" == "false" && "$DID_CODEX" == "false" && "$DID_GEMINI" == "false" ]]; then
+  display_config_instructions "$VPY" "$SCRIPT_DIR/mcp_server.py" || true
+fi

--- a/tests/test_git_pr_resolver.py
+++ b/tests/test_git_pr_resolver.py
@@ -1,0 +1,106 @@
+import httpx
+import pytest
+
+from git_pr_resolver import (
+    api_base_for_host,
+    git_detect_repo_branch,
+    parse_remote_url,
+    resolve_pr_url,
+)
+
+
+def test_parse_remote_url_variants():
+    assert parse_remote_url("https://github.com/a/b") == ("github.com", "a", "b")
+    assert parse_remote_url("https://github.com/a/b.git") == ("github.com", "a", "b")
+    assert parse_remote_url("git@github.com:a/b.git") == ("github.com", "a", "b")
+
+
+def test_api_base_for_host_ghe(monkeypatch):
+    assert api_base_for_host("github.mycorp.com") == "https://github.mycorp.com/api/v3"
+    monkeypatch.setenv("GITHUB_API_URL", "https://ghe.example/api/v3/")
+    assert api_base_for_host("anything") == "https://ghe.example/api/v3"
+
+
+def test_git_detect_repo_branch_env_override(monkeypatch):
+    monkeypatch.setenv("MCP_PR_OWNER", "o")
+    monkeypatch.setenv("MCP_PR_REPO", "r")
+    monkeypatch.setenv("MCP_PR_BRANCH", "b")
+    ctx = git_detect_repo_branch()
+    assert ctx.owner == "o" and ctx.repo == "r" and ctx.branch == "b"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pr_url_branch_strategy(monkeypatch):
+    class DummyResp:
+        def __init__(self, json_data, status_code=200):
+            self._json = json_data
+            self.status_code = status_code
+            self.headers = {}
+
+        def json(self):
+            return self._json
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError("error", request=None, response=None)
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, headers=None):
+            if "head=o:branch" in url:
+                return DummyResp(
+                    [{"html_url": "https://github.com/o/r/pull/1", "number": 1}]
+                )
+            return DummyResp([])
+
+    monkeypatch.setattr(
+        "git_pr_resolver.httpx.AsyncClient", lambda *a, **k: FakeClient()
+    )
+
+    url = await resolve_pr_url("o", "r", branch="branch", select_strategy="branch")
+    assert url.endswith("/pull/1")
+
+
+@pytest.mark.asyncio
+async def test_resolve_pr_url_uses_follow_redirects(monkeypatch):
+    class DummyResp:
+        def __init__(self, json_data, status_code=200):
+            self._json = json_data
+            self.status_code = status_code
+            self.headers = {}
+
+        def json(self):
+            return self._json
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError("error", request=None, response=None)
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            # Ensure our code passed follow_redirects=True
+            assert kwargs.get("follow_redirects", False) is True
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, headers=None):
+            # Return a simple open PR list
+            return DummyResp(
+                [{"html_url": "https://github.com/o/r/pull/2", "number": 2}]
+            )
+
+    monkeypatch.setattr(
+        "git_pr_resolver.httpx.AsyncClient", lambda *a, **k: FakeClient(*a, **k)
+    )
+
+    url = await resolve_pr_url("o", "r", branch=None, select_strategy="latest")
+    assert url.endswith("/pull/2")

--- a/tests/test_git_pr_resolver.py
+++ b/tests/test_git_pr_resolver.py
@@ -16,7 +16,10 @@ def test_parse_remote_url_variants():
 
 
 def test_api_base_for_host_ghe(monkeypatch):
+    # Ensure no global override interferes with default behavior
+    monkeypatch.delenv("GITHUB_API_URL", raising=False)
     assert api_base_for_host("github.mycorp.com") == "https://github.mycorp.com/api/v3"
+    # When override is present, it should take precedence and be normalized
     monkeypatch.setenv("GITHUB_API_URL", "https://ghe.example/api/v3/")
     assert api_base_for_host("anything") == "https://ghe.example/api/v3"
 

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,39 @@ wheels = [
 ]
 
 [[package]]
+name = "dulwich"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f3/13a3425ddf04bd31f1caf3f4fa8de2352700c454cb0536ce3f4dbdc57a81/dulwich-0.24.1.tar.gz", hash = "sha256:e19fd864f10f02bb834bb86167d92dcca1c228451b04458761fc13dabd447758", size = 806136, upload-time = "2025-08-01T10:26:46.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/90/6ab0a7667d3e588d6a2808e09fb273565458d53bed0f424ec2a4e238be0c/dulwich-0.24.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2169c36b7955b40e1ec9b0543301a3dd536718c3b7840959ca70e7ed17397c25", size = 1091946, upload-time = "2025-08-01T10:26:03.28Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a6/c13168490a926f84447e9035fb5d10504d7c4d81a68162a900c59b1fc0fe/dulwich-0.24.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d16507ca6d6c2d29d7d942da4cc50fa589d58ab066030992dfa3932de6695062", size = 1162928, upload-time = "2025-08-01T10:26:05.763Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f9/c248185bf982f2efbc02f1de5783b0e4aae94975b07d293e2aae1901c4b1/dulwich-0.24.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e893b800c72499e21d0160169bac574292626193532c336ffce7617fe02d97db", size = 1168496, upload-time = "2025-08-01T10:26:07.216Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c0/1f1ab43fbe41a43ed918641d3111775c983dd0a442a7675c35121f8bd49b/dulwich-0.24.1-cp310-cp310-win32.whl", hash = "sha256:d7144febcad9e8510ed870a141073b07071390421691285a81cea5b9fa38d888", size = 764060, upload-time = "2025-08-01T10:26:08.725Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0c/19c815b597e112ea41c67f28bef2715eef230c51d168bf290dcbbad81eaf/dulwich-0.24.1-cp310-cp310-win_amd64.whl", hash = "sha256:1d8226ca444c4347e5820b4a0a3a8f91753c0e39e335eee1eaf59d9672356a9c", size = 780474, upload-time = "2025-08-01T10:26:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/93/46/efc7dde236144384277a18f27f584370a796a1c547cc94ff4f208d381a18/dulwich-0.24.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:31ad6637322aaafeecc4c884f396ac2d963aadf201deb6422134fa0f8ac9a87a", size = 1091732, upload-time = "2025-08-01T10:26:12.021Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ec/34c93eb4295adccf1395e363cdf7200ecd4ec0a96b6cea43ff19074980c9/dulwich-0.24.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:358e4b688f6c1fa5346a8394a2c1ab79ff7126be576b20ffd0f38085ead0df54", size = 1162365, upload-time = "2025-08-01T10:26:13.48Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/90/16f4a0281a35adc7678245d8f47aaf48358e936903af69d2f18aa98b9990/dulwich-0.24.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:50f981edd5307475f6f862ccdbe39e8dd01afc17f2ed8ee0e452c3878389b48c", size = 1167573, upload-time = "2025-08-01T10:26:14.972Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fc/961308a475f6a26dc0e9360afd5cade20e164bb08bb3bbf7edabacddcdd7/dulwich-0.24.1-cp311-cp311-win32.whl", hash = "sha256:741417a6a029a3230c46ad4725a50440cac852f165706824303d9939cf83770c", size = 763597, upload-time = "2025-08-01T10:26:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/001fb17046c8d8dffed6b205950d6cb82f3e8b6cd8561a3f9395759d0fd3/dulwich-0.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:816ec4abd152ebd11d05bf25b5d37a4a88c18af59857067ee85d32e43af12b5f", size = 779975, upload-time = "2025-08-01T10:26:18.191Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/ccefebfc92ab682364ca247ba0e364f2826085ce75a314822d117a1dda49/dulwich-0.24.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d227cebcb2082801ab429e196d973315dbe3818904b5c13a22d80a16f5692c9", size = 1080906, upload-time = "2025-08-01T10:26:19.664Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/18/6abaf1973fd71cee2e9cf1e611944936481d7fc63a63c2974f01cc4cd9ca/dulwich-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5e3c01b8109169aa361842af4987bca672087e3faf38d528ff9f631d1071f523", size = 1159961, upload-time = "2025-08-01T10:26:21.077Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c7/09dc31cf769ca1e67445f530e58df4af9379842b8740b88efcf44448627b/dulwich-0.24.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee80d8e9199124974b486d2c83a7e2d4db17ae59682909fa198111d8bb416f50", size = 1164723, upload-time = "2025-08-01T10:26:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/528e4be601948be340fbd61bed99ccd1dcade38254aae804412d8e016246/dulwich-0.24.1-cp312-cp312-win32.whl", hash = "sha256:bef4dccba44edd6d18015f67c9e0d6216f978840cdbe703930e1679e2872c595", size = 762743, upload-time = "2025-08-01T10:26:24.013Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/e8/c50cb473325d91435be9af61e14d240e67632ff24b83eb2c04e6cd76af33/dulwich-0.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:83b2fb17bac190cfc6c91e7a94a1d806aa8ce8903aca0e3e54cecb2c3f547a55", size = 780044, upload-time = "2025-08-01T10:26:25.498Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/3f4760169fea1b90df7aea88172699807af6f4f667c878de6a9ee554170f/dulwich-0.24.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a11ec69fc6604228804ddfc32c85b22bc627eca4cf4ff3f27dbe822e6f29477", size = 1080923, upload-time = "2025-08-01T10:26:28.011Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d9/7aadd6318aed6f0e1242fa63bd61d80142716d13ea4e307c8b19fc61c9ae/dulwich-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a9800df7238b586b4c38c00432776781bc889cf02d756dcfb8dc0ecb8fc47a33", size = 1159246, upload-time = "2025-08-01T10:26:29.487Z" },
+    { url = "https://files.pythonhosted.org/packages/90/5d/df4256fe009c714e0392817df4fdc1748a901523504f58796d675fce755f/dulwich-0.24.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3baab4a01aff890e2e6551ccbd33eb2a44173c897f0f027ad3aeab0fb057ec44", size = 1163646, upload-time = "2025-08-01T10:26:31.279Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/850115d6fa7ad03756e20466ad5b72be54d1b59c1ff7d2b3c13bc4de965f/dulwich-0.24.1-cp313-cp313-win32.whl", hash = "sha256:b39689aa4d143ba1fb0a687a4eb93d2e630d2c8f940aaa6c6911e9c8dca16e6a", size = 762612, upload-time = "2025-08-01T10:26:33.223Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7f/f79940e0773efda2ed0e666a0ca0ae7c734fdce4f04b5b60bc5ed268b7cb/dulwich-0.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:8fca9b863b939b52c5f759d292499f0d21a7bf7f8cbb9fdeb8cdd9511c5bc973", size = 779168, upload-time = "2025-08-01T10:26:35.303Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bc/a2557d1b0afa5bf1e140f42f8cbca1783e43d7fa17665859c63060957952/dulwich-0.24.1-py3-none-any.whl", hash = "sha256:57cc0dc5a21059698ffa4ed9a7272f1040ec48535193df84b0ee6b16bf615676", size = 440765, upload-time = "2025-08-01T10:26:45.415Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -214,6 +247,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "dulwich" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "python-dotenv" },
@@ -238,6 +272,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=23.2.1" },
+    { name = "dulwich", specifier = ">=0.22.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
@@ -749,6 +784,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds auto-resolution of the current repository's open PR when a URL is not provided to the MCP tool, using dulwich for git detection.

Changes
- Add `git_pr_resolver` using dulwich to detect repo/branch and resolve open PRs.
- Update MCP tool: make `pr_url` optional; add `select_strategy`, `owner`, `repo`, `branch` parameters.
- Follow 301 redirects in both resolver and comment fetcher.
- Add tests for resolver, env overrides, and redirect handling.
- Add dulwich dependency.

Why
- Enables agents/CLI usage without needing to paste a PR URL.
- Removes dependency on system git, improving portability.

Backwards Compatibility
- Passing an explicit `pr_url` preserves current behaviour.

Testing
- `uv run ruff check --fix . && uv run ruff format .` passes.
- `uv run pytest -q` passes.