### PR TITLE
Handle trailing components in PR URL parser

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -33,8 +33,17 @@ MAX_RETRIES_MIN, MAX_RETRIES_MAX = 0, 10
 
 # Helper functions can remain at the module level as they are pure functions.
 def get_pr_info(pr_url: str) -> tuple[str, str, str]:
-    """Parses a GitHub PR URL to extract owner, repo, and pull number."""
-    pattern = r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)$"
+    """Parses a GitHub PR URL to extract owner, repo, and pull number.
+
+    Accepts URLs of the form ``https://github.com/<owner>/<repo>/pull/<number>``
+    with optional trailing path segments, query strings, or fragments (e.g.
+    ``?diff=split`` or ``/files``). The core structure must match the pattern
+    above; unrelated URLs such as issues are rejected.
+    """
+
+    # Allow optional trailing ``/...``, query string, or fragment after the PR
+    # number.  Everything up to ``pull/<num>`` must match exactly.
+    pattern = r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$"
     match = re.match(pattern, pr_url)
     if not match:
         raise ValueError(

--- a/tests/test_get_pr_info.py
+++ b/tests/test_get_pr_info.py
@@ -16,6 +16,21 @@ def test_get_pr_info_accepts_suffixes(url: str) -> None:
     assert get_pr_info(url) == ("owner", "repo", "123")
 
 
-def test_get_pr_info_invalid_url() -> None:
+@pytest.mark.parametrize(
+    "invalid_url",
+    [
+        # Not a pull request URL
+        "https://github.com/owner/repo/issues/123",
+        # Missing PR number
+        "https://github.com/owner/repo/pull/",
+        # Invalid characters after PR number without a separator
+        "https://github.com/owner/repo/pull/123foo",
+        # Different host
+        "https://gitlab.com/owner/repo/pull/123",
+        # Non-numeric PR number
+        "https://github.com/owner/repo/pull/abc",
+    ],
+)
+def test_get_pr_info_invalid_url(invalid_url: str) -> None:
     with pytest.raises(ValueError):
-        get_pr_info("https://github.com/owner/repo/issues/123")
+        get_pr_info(invalid_url)

--- a/tests/test_get_pr_info.py
+++ b/tests/test_get_pr_info.py
@@ -1,0 +1,21 @@
+import pytest
+
+from mcp_server import get_pr_info
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/owner/repo/pull/123/",
+        "https://github.com/owner/repo/pull/123/files",
+        "https://github.com/owner/repo/pull/123?diff=split",
+        "https://github.com/owner/repo/pull/123/files?foo=bar#fragment",
+    ],
+)
+def test_get_pr_info_accepts_suffixes(url: str) -> None:
+    assert get_pr_info(url) == ("owner", "repo", "123")
+
+
+def test_get_pr_info_invalid_url() -> None:
+    with pytest.raises(ValueError):
+        get_pr_info("https://github.com/owner/repo/issues/123")


### PR DESCRIPTION
## Summary
- relax `get_pr_info` to accept PR URLs with trailing slashes, extra path segments, and query strings
- document supported PR URL variants
- add regression tests for various PR URL suffixes and invalid URLs

## Testing
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `make compile-check`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be1b728a30832187e5aa9d9b60c158