### PR TITLE
fix(git): trim whitespace in remote URL parsing

### DIFF
--- a/git_pr_resolver.py
+++ b/git_pr_resolver.py
@@ -32,6 +32,7 @@ REMOTE_REGEXES = [
 
 
 def parse_remote_url(url: str) -> tuple[str, str, str]:
+    url = url.strip()
     for rx in REMOTE_REGEXES:
         m = rx.match(url)
         if m:

--- a/tests/test_git_pr_resolver.py
+++ b/tests/test_git_pr_resolver.py
@@ -1,6 +1,6 @@
 import pytest
-
 from conftest import DummyResp, FakeClient, create_mock_response
+
 from git_pr_resolver import (
     api_base_for_host,
     git_detect_repo_branch,
@@ -115,6 +115,10 @@ def test_parse_remote_url_edge_cases() -> None:
             "https://github.com/owner/my.repo.name",
             ("github.com", "owner", "my.repo.name"),
         ),  # Repository name with dots
+        (
+            "  https://github.com/owner/repo.git  \n",
+            ("github.com", "owner", "repo"),
+        ),  # Surrounding whitespace and newline
     ]
 
     for url, expected in success_cases:

--- a/tests/test_git_pr_resolver.py
+++ b/tests/test_git_pr_resolver.py
@@ -119,6 +119,10 @@ def test_parse_remote_url_edge_cases() -> None:
             "  https://github.com/owner/repo.git  \n",
             ("github.com", "owner", "repo"),
         ),  # Surrounding whitespace and newline
+        (
+            "\tgit@github.com:owner/repo.git\t",
+            ("github.com", "owner", "repo"),
+        ),  # SSH URL with surrounding tabs
     ]
 
     for url, expected in success_cases:


### PR DESCRIPTION
## Summary
- strip leading and trailing whitespace before parsing remote git URLs
- ensure remote URL parser handles whitespace via new test coverage

## Testing
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `make compile-check`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be2beb9c7c8321a83af633a46f3e42