### PR TITLE
chore: enable mypy coverage and refine types

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Run Ruff formatter check
         run: uv run ruff format --check .
       
-      - name: Type check with mypy
-        continue-on-error: true
-        run: uv run mypy --strict mcp_server.py git_pr_resolver.py
+      - name: Type check with mypy and report coverage
+        run: |
+          uv run mypy --strict --linecount-report .mypy-coverage .
+          cat .mypy-coverage/linecount.txt

--- a/git_pr_resolver.py
+++ b/git_pr_resolver.py
@@ -7,6 +7,7 @@ from urllib.parse import quote
 
 import httpx
 from dulwich import porcelain
+from dulwich.config import ConfigFile
 from dulwich.errors import NotGitRepository
 from dulwich.repo import Repo
 
@@ -65,7 +66,7 @@ def git_detect_repo_branch(cwd: str | None = None) -> GitContext:
     repo_obj = _get_repo(cwd)
 
     # Remote URL: prefer 'origin'
-    cfg: Any = repo_obj.get_config()
+    cfg: ConfigFile = repo_obj.get_config()
     remote_url_b: bytes | None = None
     try:
         remote_url_b = cfg.get((b"remote", b"origin"), b"url")


### PR DESCRIPTION
## Summary
- report mypy type coverage in lint workflow
- strengthen typing for GitHub comment handling and git config

## Testing
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `make compile-check`
- `uv run pytest -q`
- `uv run mypy --strict --linecount-report .mypy-coverage mcp_server.py git_pr_resolver.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3ba38e0c8321a6c20bee7f48a82a