### PR TITLE
feat(mcp): add mimeType metadata to tool outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ Fetches all review comments from a given GitHub pull request URL. The tool now r
     -   `max_retries` (int, optional): Retry budget for transient errors. Defaults from env `HTTP_MAX_RETRIES`.
 
 -   **Returns:**
-    -   When `output="markdown"` (default): a single text item containing Markdown.
-    -   When `output="json"`: a single text item containing a JSON string with the raw comments list.
-    -   When `output="both"`: two text items in order — first Markdown, then JSON.
+    -   When `output="markdown"` (default): a single text item containing Markdown, with `mimeType` `text/markdown`.
+    -   When `output="json"`: a single text item containing a JSON string with the raw comments list, with `mimeType` `application/json`.
+    -   When `output="both"`: two text items in order — first Markdown, then JSON, each with its corresponding `mimeType`.
 
 Example (Markdown default):
 ```json


### PR DESCRIPTION
## Summary
- default to markdown for `fetch_pr_review_comments`
- attach `mimeType` metadata to MCP tool responses
- document new metadata and test tool output ordering

## Testing
- `uv run ruff check mcp_server.py tests/test_mcp_server_tools.py`
- `uv run python -m compileall -q -f .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be3f02f1748321b1efede86ad86612