### PR TITLE
feat(mcp): expose spec files as resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ Creates a markdown file. Prefer passing pre-rendered `markdown` (e.g., the outpu
 -   **Returns:**
     -   A string indicating whether the file was created successfully or if an error occurred. Files are created under `./review_specs/` with exclusive create to avoid overwrite.
 
+### MCP Resources
+
+Generated spec files are exposed as [MCP resources](https://github.com/modelcontextprotocol/modelcontextprotocol).
+Clients can list available specs and read their contents:
+
+- `list_resources` returns Markdown files in the `review_specs/` directory.
+- `read_resource` retrieves the Markdown text for a given resource URI.
+
 ### GitHub Token Scopes
 
 Use least privilege for `GITHUB_TOKEN`:


### PR DESCRIPTION
## Summary
- add list_resources and read_resource handlers to serve review specs as MCP resources
- document resource support and test listing/reading of generated specs
- default fetch_pr_review_comments to markdown and annotate outputs with MIME types; parametrize MIME type tests

## Testing
- `uv run ruff format mcp_server.py tests/test_mcp_server_tools.py`
- `uv run ruff check --fix mcp_server.py tests/test_mcp_server_tools.py`
- `make compile-check`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be3f02f1748321b1efede86ad86612