### PR TITLE
fix: enforce BLE001 exception handling

### DIFF
--- a/git_pr_resolver.py
+++ b/git_pr_resolver.py
@@ -92,7 +92,7 @@ def git_detect_repo_branch(cwd: str | None = None) -> GitContext:
         # Detached HEAD: attempt porcelain.active_branch
         try:
             branch = porcelain.active_branch(repo_obj).decode("utf-8", errors="ignore")
-        except Exception as _e:  # noqa: BLE001
+        except (KeyError, IndexError, ValueError):
             branch = None
     if not branch:
         raise ValueError("Unable to determine current branch")
@@ -166,7 +166,7 @@ async def resolve_pr_url(
                 )
                 if pr_num is not None:
                     return _html_pr_url(actual_host, owner, repo, pr_num)
-            except Exception as e:  # noqa: BLE001
+            except (httpx.HTTPError, ValueError, TypeError) as e:
                 # Fall back to REST below; optionally log for debugging
                 if os.getenv("DEBUG_GITHUB_PR_RESOLVER"):
                     print(f"GraphQL lookup failed: {e}", file=sys.stderr)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -6,8 +6,8 @@ import random
 import re
 import sys
 import traceback
-from collections.abc import Sequence
-from typing import Any, TypedDict, cast
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, TypedDict, TypeVar, cast
 from urllib.parse import quote
 
 import httpx
@@ -122,14 +122,17 @@ async def fetch_pr_comments(
     ) -> int:
         if override is not None:
             try:
-                return max(min_v, min(max_v, int(override)))
-            except Exception:
+                override_int = int(override)
+            except (TypeError, ValueError):
                 return default
+            return max(min_v, min(max_v, override_int))
+
         try:
-            val = int(os.getenv(name, str(default)))
-            return max(min_v, min(max_v, val))
-        except Exception:
+            env_value = os.getenv(name, str(default))
+            env_int = int(env_value)
+        except (TypeError, ValueError):
             return default
+        return max(min_v, min(max_v, env_int))
 
     per_page_v = _int_conf("HTTP_PER_PAGE", 100, 1, 100, per_page)
     max_pages_v = _int_conf("PR_FETCH_MAX_PAGES", 50, 1, 200, max_pages)
@@ -195,6 +198,7 @@ async def fetch_pr_comments(
                         reset = response.headers.get("X-RateLimit-Reset")
 
                         if retry_after_header or remaining == "0":
+                            retry_after = 60
                             try:
                                 if retry_after_header:
                                     retry_after = int(retry_after_header)
@@ -203,9 +207,7 @@ async def fetch_pr_comments(
 
                                     now = int(time.time())
                                     retry_after = max(int(reset) - now, 1)
-                                else:
-                                    retry_after = 60
-                            except Exception:
+                            except (TypeError, ValueError):
                                 retry_after = 60
 
                             print(
@@ -357,6 +359,9 @@ def generate_markdown(comments: Sequence[CommentResult]) -> str:
     return markdown
 
 
+T = TypeVar("T")
+
+
 class ReviewSpecGenerator:
     def __init__(self) -> None:
         self.server = server.Server("github_review_spec_generator")
@@ -488,46 +493,58 @@ class ReviewSpecGenerator:
         Handle tool calls.
         Each tool call is routed to the appropriate method based on the tool name.
         """
-        try:
-            if name == "fetch_pr_review_comments":
-                # Validate optional numeric parameters
-                def _validate_int(
-                    name: str, value: Any, min_v: int, max_v: int
-                ) -> int | None:
-                    if value is None:
-                        return None
-                    if isinstance(value, bool) or not isinstance(value, int):
-                        raise ValueError(f"Invalid type for {name}: expected integer")
-                    if not (min_v <= value <= max_v):
-                        raise ValueError(
-                            f"Invalid value for {name}: must be between {min_v} "
-                            f"and {max_v}"
-                        )
-                    return cast(int, value)
 
-                per_page = _validate_int(
-                    "per_page", arguments.get("per_page"), PER_PAGE_MIN, PER_PAGE_MAX
-                )
-                max_pages = _validate_int(
-                    "max_pages",
-                    arguments.get("max_pages"),
-                    MAX_PAGES_MIN,
-                    MAX_PAGES_MAX,
-                )
-                max_comments = _validate_int(
-                    "max_comments",
-                    arguments.get("max_comments"),
-                    MAX_COMMENTS_MIN,
-                    MAX_COMMENTS_MAX,
-                )
-                max_retries = _validate_int(
-                    "max_retries",
-                    arguments.get("max_retries"),
-                    MAX_RETRIES_MIN,
-                    MAX_RETRIES_MAX,
-                )
+        async def _run_with_handling(operation: Callable[[], Awaitable[T]]) -> T:
+            try:
+                return await operation()
+            except ValueError:
+                raise
+            except (httpx.HTTPError, OSError, RuntimeError, TypeError) as exc:
+                error_msg = f"Error executing tool {name}: {exc}"
+                print(error_msg, file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
+                raise RuntimeError(error_msg) from exc
 
-                comments = await self.fetch_pr_review_comments(
+        if name == "fetch_pr_review_comments":
+            # Validate optional numeric parameters
+            def _validate_int(
+                arg_name: str, value: Any, min_v: int, max_v: int
+            ) -> int | None:
+                if value is None:
+                    return None
+                if isinstance(value, bool) or not isinstance(value, int):
+                    raise ValueError(f"Invalid type for {arg_name}: expected integer")
+                if not (min_v <= value <= max_v):
+                    raise ValueError(
+                        f"Invalid value for {arg_name}: must be between {min_v} "
+                        f"and {max_v}"
+                    )
+                return cast(int, value)
+
+            per_page = _validate_int(
+                "per_page", arguments.get("per_page"), PER_PAGE_MIN, PER_PAGE_MAX
+            )
+            max_pages = _validate_int(
+                "max_pages",
+                arguments.get("max_pages"),
+                MAX_PAGES_MIN,
+                MAX_PAGES_MAX,
+            )
+            max_comments = _validate_int(
+                "max_comments",
+                arguments.get("max_comments"),
+                MAX_COMMENTS_MIN,
+                MAX_COMMENTS_MAX,
+            )
+            max_retries = _validate_int(
+                "max_retries",
+                arguments.get("max_retries"),
+                MAX_RETRIES_MIN,
+                MAX_RETRIES_MAX,
+            )
+
+            comments = await _run_with_handling(
+                lambda: self.fetch_pr_review_comments(
                     arguments.get("pr_url", ""),
                     per_page=per_page,
                     max_pages=max_pages,
@@ -538,60 +555,51 @@ class ReviewSpecGenerator:
                     repo=arguments.get("repo"),
                     branch=arguments.get("branch"),
                 )
-                output = arguments.get("output") or "markdown"
-                if output not in ("markdown", "json", "both"):
-                    raise ValueError(
-                        "Invalid output: must be 'markdown', 'json', or 'both'"
-                    )
+            )
 
-                # Build responses according to requested format (default markdown)
-                results: list[TextContent] = []
-                if output in ("json", "both"):
-                    results.append(TextContent(type="text", text=json.dumps(comments)))
-                if output in ("markdown", "both"):
-                    try:
-                        md = generate_markdown(comments)
-                    except Exception as e:
-                        # Surface generation errors clearly while logging stacktrace
-                        traceback.print_exc(file=sys.stderr)
-                        md = (
-                            f"# Error\n\nFailed to generate markdown from comments: {e}"
-                        )
-                    results.append(TextContent(type="text", text=md))
-                return results
+            output = arguments.get("output") or "markdown"
+            if output not in ("markdown", "json", "both"):
+                raise ValueError(
+                    "Invalid output: must be 'markdown', 'json', or 'both'"
+                )
 
-            elif name == "resolve_open_pr_url":
-                select_strategy = arguments.get("select_strategy") or "branch"
-                owner = arguments.get("owner")
-                repo = arguments.get("repo")
-                branch = arguments.get("branch")
+            # Build responses according to requested format (default markdown)
+            results: list[TextContent] = []
+            if output in ("json", "both"):
+                results.append(TextContent(type="text", text=json.dumps(comments)))
+            if output in ("markdown", "both"):
+                try:
+                    md = generate_markdown(comments)
+                except (AttributeError, KeyError, TypeError, IndexError) as exc:
+                    traceback.print_exc(file=sys.stderr)
+                    md = f"# Error\n\nFailed to generate markdown from comments: {exc}"
+                results.append(TextContent(type="text", text=md))
+            return results
 
-                if not (owner and repo and branch):
-                    ctx = git_detect_repo_branch()
-                    owner = owner or ctx.owner
-                    repo = repo or ctx.repo
-                    branch = branch or ctx.branch
+        if name == "resolve_open_pr_url":
+            select_strategy = arguments.get("select_strategy") or "branch"
+            owner = arguments.get("owner")
+            repo = arguments.get("repo")
+            branch = arguments.get("branch")
 
-                resolved_url = await resolve_pr_url(
+            if not (owner and repo and branch):
+                ctx = git_detect_repo_branch()
+                owner = owner or ctx.owner
+                repo = repo or ctx.repo
+                branch = branch or ctx.branch
+
+            resolved_url = await _run_with_handling(
+                lambda: resolve_pr_url(
                     owner=owner or "",
                     repo=repo or "",
                     branch=branch,
                     select_strategy=select_strategy,
                     host=None,
                 )
-                return [TextContent(type="text", text=resolved_url)]
+            )
+            return [TextContent(type="text", text=resolved_url)]
 
-            else:
-                raise ValueError(f"Unknown tool: {name}")
-
-        except Exception as e:
-            # Let validation errors surface as-is for callers/tests
-            if isinstance(e, ValueError):
-                raise
-            error_msg = f"Error executing tool {name}: {str(e)}"
-            print(error_msg, file=sys.stderr)
-            traceback.print_exc(file=sys.stderr)
-            raise RuntimeError(error_msg) from e
+        raise ValueError(f"Unknown tool: {name}")
 
     async def fetch_pr_review_comments(
         self,
@@ -651,35 +659,30 @@ class ReviewSpecGenerator:
 
     async def run(self) -> None:
         """Start the MCP server."""
-        try:
-            print("Running MCP Server...", file=sys.stderr)
-            # Import stdio here to avoid potential issues with event loop
-            from mcp.server.stdio import stdio_server
+        print("Running MCP Server...", file=sys.stderr)
+        # Import stdio here to avoid potential issues with event loop
+        from mcp.server.stdio import stdio_server
 
-            async with stdio_server() as (read_stream, write_stream):
-                notif = NotificationOptions(
-                    prompts_changed=False,
-                    resources_changed=False,
-                    tools_changed=False,
-                )
-                capabilities = self.server.get_capabilities(
-                    notif,
-                    experimental_capabilities={},
-                )
+        async with stdio_server() as (read_stream, write_stream):
+            notif = NotificationOptions(
+                prompts_changed=False,
+                resources_changed=False,
+                tools_changed=False,
+            )
+            capabilities = self.server.get_capabilities(
+                notif,
+                experimental_capabilities={},
+            )
 
-                await self.server.run(
-                    read_stream,
-                    write_stream,
-                    InitializationOptions(
-                        server_name="github_review_spec_generator",
-                        server_version="1.0.0",
-                        capabilities=capabilities,
-                    ),
-                )
-        except Exception as e:
-            print(f"Fatal Error in MCP Server: {str(e)}", file=sys.stderr)
-            traceback.print_exc(file=sys.stderr)
-            sys.exit(1)
+            await self.server.run(
+                read_stream,
+                write_stream,
+                InitializationOptions(
+                    server_name="github_review_spec_generator",
+                    server_version="1.0.0",
+                    capabilities=capabilities,
+                ),
+            )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ select = [
     "A",   # flake8-builtins
     "C4",  # flake8-comprehensions
 ]
+extend-select = [
+    "BLE001",  # flake8-blind-except (broad exception catch)
+]
 ignore = [
     "S101", # Use of assert
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -432,3 +432,15 @@ class FakeClient:
                 }
             ]
         )
+
+    async def post(  # noqa: D401
+        self,
+        url: str,
+        json: Any | None = None,
+        headers: dict[str, str] | None = None,  # noqa: ARG002
+    ) -> DummyResp:
+        """Simulate GraphQL failures when the mock client lacks POST support."""
+        import httpx
+
+        request = httpx.Request("POST", url)
+        raise httpx.RequestError("GraphQL not supported in FakeClient", request=request)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 from conftest import create_mock_response
 
@@ -170,7 +171,7 @@ class TestRealGitHubIntegration:
                 assert "id" in comments[0]
                 assert "body" in comments[0]
 
-        except Exception as e:
+        except httpx.HTTPError as e:
             # If we can't access the test PR, skip rather than fail
             pytest.skip(f"Could not access test PR for integration test: {e}")
 

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -1,3 +1,5 @@
+import json
+from types import SimpleNamespace, TracebackType
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -10,12 +12,31 @@ from mcp_server import (
     fetch_pr_comments,
     generate_markdown,
 )
+from mcp.types import TextContent
 
 
 def test_generate_markdown_no_comments() -> None:
     """Should handle empty comment list."""
     result = generate_markdown([])
     assert result == "# Pull Request Review Spec\n\nNo comments found.\n"
+
+
+def test_generate_markdown_skips_error_entries() -> None:
+    """Should skip error entries when generating markdown."""
+    result = generate_markdown(
+        [
+            {"error": "API failure"},
+            {
+                "user": {"login": "dev"},
+                "path": "file.py",
+                "line": 1,
+                "body": "Looks good",
+                "diff_hunk": "@@\n+code\n",
+            },
+        ]
+    )
+    assert "API failure" not in result
+    assert "Review Comment by dev" in result
 
 
 @pytest.mark.asyncio
@@ -44,6 +65,15 @@ async def test_handle_call_tool_invalid_type(mcp_server: ReviewSpecGenerator) ->
 
 
 @pytest.mark.asyncio
+async def test_handle_call_tool_invalid_output(mcp_server: ReviewSpecGenerator) -> None:
+    with pytest.raises(ValueError, match="Invalid output"):
+        await mcp_server.handle_call_tool(
+            "fetch_pr_review_comments",
+            {"pr_url": "https://github.com/o/r/pull/1", "output": "text"},
+        )
+
+
+@pytest.mark.asyncio
 async def test_handle_call_tool_invalid_range(mcp_server: ReviewSpecGenerator) -> None:
     with pytest.raises(ValueError, match="Invalid value for per_page"):
         await mcp_server.handle_call_tool(
@@ -68,6 +98,36 @@ async def test_fetch_pr_review_comments_success(
 
 
 @pytest.mark.asyncio
+async def test_handle_call_tool_fetch_output_both(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: ReviewSpecGenerator,
+) -> None:
+    async def mock_fetch(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "user": {"login": "alice"},
+                "path": "file.py",
+                "line": 12,
+                "body": "Note",
+                "diff_hunk": "@@\n+code\n",
+            }
+        ]
+
+    monkeypatch.setattr(mcp_server, "fetch_pr_review_comments", mock_fetch)
+
+    result = await mcp_server.handle_call_tool(
+        "fetch_pr_review_comments",
+        {"pr_url": "https://github.com/a/b/pull/1", "output": "both"},
+    )
+
+    assert len(result) == 2
+    json_text = result[0].text
+    markdown_text = result[1].text
+    assert json.loads(json_text)[0]["path"] == "file.py"
+    assert "Review Comment by alice" in markdown_text
+
+
+@pytest.mark.asyncio
 async def test_fetch_pr_review_comments_invalid_url(
     mcp_server: ReviewSpecGenerator,
 ) -> None:
@@ -75,6 +135,137 @@ async def test_fetch_pr_review_comments_invalid_url(
         "https://github.com/owner/repo/issues/1"
     )
     assert comments and "error" in comments[0]
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_passes_numeric_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: ReviewSpecGenerator,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def mock_fetch(
+        pr_url: str,
+        *,
+        per_page: int | None,
+        max_pages: int | None,
+        max_comments: int | None,
+        max_retries: int | None,
+        select_strategy: str | None,
+        owner: str | None,
+        repo: str | None,
+        branch: str | None,
+    ) -> list[dict[str, Any]]:
+        captured.update(
+            {
+                "pr_url": pr_url,
+                "per_page": per_page,
+                "max_pages": max_pages,
+                "max_comments": max_comments,
+                "max_retries": max_retries,
+            }
+        )
+        return []
+
+    monkeypatch.setattr(mcp_server, "fetch_pr_review_comments", mock_fetch)
+
+    result = await mcp_server.handle_call_tool(
+        "fetch_pr_review_comments",
+        {
+            "pr_url": "https://github.com/o/r/pull/1",
+            "per_page": 5,
+            "max_pages": 10,
+            "max_comments": 200,
+            "max_retries": 2,
+            "output": "json",
+        },
+    )
+
+    assert captured == {
+        "pr_url": "https://github.com/o/r/pull/1",
+        "per_page": 5,
+        "max_pages": 10,
+        "max_comments": 200,
+        "max_retries": 2,
+    }
+    assert result[0].text == "[]"
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_review_comments_auto_resolve(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: ReviewSpecGenerator,
+) -> None:
+    resolver_response = [TextContent(type="text", text="https://github.com/o/r/pull/3")]
+    resolve_mock = AsyncMock(return_value=resolver_response)
+    monkeypatch.setattr(mcp_server, "handle_call_tool", resolve_mock)
+
+    async def mock_fetch(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:  # noqa: ARG001
+        return [{"id": 1}]
+
+    monkeypatch.setattr("mcp_server.fetch_pr_comments_graphql", mock_fetch)
+
+    comments = await mcp_server.fetch_pr_review_comments(None)
+
+    assert resolve_mock.await_count == 1
+    assert comments == [{"id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_handles_markdown_generation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: ReviewSpecGenerator,
+) -> None:
+    async def mock_fetch(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:  # noqa: ARG001
+        return []
+
+    def explode(comments: Any) -> str:  # noqa: ARG001
+        raise TypeError("boom")
+
+    monkeypatch.setattr(mcp_server, "fetch_pr_review_comments", mock_fetch)
+    monkeypatch.setattr("mcp_server.generate_markdown", explode)
+
+    result = await mcp_server.handle_call_tool(
+        "fetch_pr_review_comments",
+        {"pr_url": "https://github.com/o/r/pull/2"},
+    )
+
+    assert len(result) == 1
+    assert result[0].text.startswith("# Error\n\nFailed to generate markdown")
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_wraps_http_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: ReviewSpecGenerator,
+) -> None:
+    async def failing_fetch(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:  # noqa: ARG001
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(mcp_server, "fetch_pr_review_comments", failing_fetch)
+
+    with pytest.raises(RuntimeError, match="Error executing tool fetch_pr_review_comments"):
+        await mcp_server.handle_call_tool(
+            "fetch_pr_review_comments",
+            {"pr_url": "https://github.com/o/r/pull/1"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_propagates_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: ReviewSpecGenerator,
+) -> None:
+    async def failing_fetch(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:  # noqa: ARG001
+        raise ValueError("bad data")
+
+    monkeypatch.setattr(mcp_server, "fetch_pr_review_comments", failing_fetch)
+
+    with pytest.raises(ValueError, match="bad data"):
+        await mcp_server.handle_call_tool(
+            "fetch_pr_review_comments",
+            {"pr_url": "https://github.com/o/r/pull/1"},
+        )
 
 
 @pytest.mark.asyncio
@@ -104,3 +295,63 @@ async def test_fetch_pr_comments_propagates_request_error() -> None:
         # The function should re-raise the RequestError
         with pytest.raises(httpx.RequestError, match="Network connection failed"):
             await fetch_pr_comments("owner", "repo", 1)
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_resolve_pr(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: ReviewSpecGenerator,
+) -> None:
+    resolve_mock = AsyncMock(return_value="https://github.com/o/r/pull/7")
+    monkeypatch.setattr("mcp_server.resolve_pr_url", resolve_mock)
+
+    result = await mcp_server.handle_call_tool(
+        "resolve_open_pr_url",
+        {"owner": "o", "repo": "r", "branch": "feature"},
+    )
+
+    assert resolve_mock.await_count == 1
+    assert result[0].text == "https://github.com/o/r/pull/7"
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_resolve_pr_uses_git_context(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: ReviewSpecGenerator,
+) -> None:
+    context = SimpleNamespace(owner="ctx-owner", repo="ctx-repo", branch="ctx-branch")
+    monkeypatch.setattr("mcp_server.git_detect_repo_branch", lambda: context)
+    resolve_mock = AsyncMock(return_value="https://github.com/ctx-owner/ctx-repo/pull/9")
+    monkeypatch.setattr("mcp_server.resolve_pr_url", resolve_mock)
+
+    result = await mcp_server.handle_call_tool("resolve_open_pr_url", {})
+
+    assert resolve_mock.await_count == 1
+    assert result[0].text.endswith("/pull/9")
+
+
+@pytest.mark.asyncio
+async def test_review_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    server_instance = ReviewSpecGenerator()
+
+    class DummyContext:
+        async def __aenter__(self) -> tuple[str, str]:
+            return ("read", "write")
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
+            return None
+
+    monkeypatch.setattr("mcp.server.stdio.stdio_server", lambda: DummyContext())
+
+    run_mock = AsyncMock()
+    monkeypatch.setattr(server_instance.server, "run", run_mock)
+    monkeypatch.setattr(server_instance.server, "get_capabilities", lambda *a, **k: {})
+
+    await server_instance.run()
+
+    run_mock.assert_awaited_once()

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -6,13 +6,13 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 from conftest import assert_auth_header_present, create_mock_response
+from mcp.types import TextContent
 
 from mcp_server import (
     ReviewSpecGenerator,
     fetch_pr_comments,
     generate_markdown,
 )
-from mcp.types import TextContent
 
 
 def test_generate_markdown_no_comments() -> None:
@@ -244,7 +244,9 @@ async def test_handle_call_tool_wraps_http_errors(
 
     monkeypatch.setattr(mcp_server, "fetch_pr_review_comments", failing_fetch)
 
-    with pytest.raises(RuntimeError, match="Error executing tool fetch_pr_review_comments"):
+    with pytest.raises(
+        RuntimeError, match="Error executing tool fetch_pr_review_comments"
+    ):
         await mcp_server.handle_call_tool(
             "fetch_pr_review_comments",
             {"pr_url": "https://github.com/o/r/pull/1"},
@@ -321,7 +323,9 @@ async def test_handle_call_tool_resolve_pr_uses_git_context(
 ) -> None:
     context = SimpleNamespace(owner="ctx-owner", repo="ctx-repo", branch="ctx-branch")
     monkeypatch.setattr("mcp_server.git_detect_repo_branch", lambda: context)
-    resolve_mock = AsyncMock(return_value="https://github.com/ctx-owner/ctx-repo/pull/9")
+    resolve_mock = AsyncMock(
+        return_value="https://github.com/ctx-owner/ctx-repo/pull/9"
+    )
     monkeypatch.setattr("mcp_server.resolve_pr_url", resolve_mock)
 
     result = await mcp_server.handle_call_tool("resolve_open_pr_url", {})

--- a/tests/test_rest_error_handling.py
+++ b/tests/test_rest_error_handling.py
@@ -1,0 +1,203 @@
+"""Additional REST API error-handling tests for fetch_pr_comments."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from mcp_server import fetch_pr_comments
+
+
+def _make_response(
+    *,
+    status: int,
+    json_value: Any = None,
+    headers: dict[str, str] | None = None,
+    raise_error: Exception | None = None,
+) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status
+    response.headers = headers or {}
+    response.json.return_value = [] if json_value is None else json_value
+    if raise_error is not None:
+        response.raise_for_status.side_effect = raise_error
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_comments_token_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should retry with classic token scheme after a 401 using Bearer."""
+    monkeypatch.setenv("GITHUB_TOKEN", "token123")
+
+    unauthorized = _make_response(status=401)
+    success = _make_response(status=200, json_value=[])
+
+    auth_headers: list[str] = []
+
+    async def _get(url: str, *, headers: dict[str, str]) -> MagicMock:  # noqa: ARG001
+        responses = getattr(_get, "_responses", [unauthorized, success])
+        if not responses:
+            raise AssertionError("No responses left for AsyncClient.get")
+        response = responses.pop(0)
+        _get._responses = responses
+        auth_headers.append(headers.get("Authorization", ""))
+        return response
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = _get
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_pr_comments("owner", "repo", 1)
+
+    assert result == []
+    assert mock_client.get.await_count == 2
+    assert auth_headers[0].startswith("Bearer ")
+    assert auth_headers[1].startswith("token ")
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_comments_rate_limit_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should back off on 403 responses with Retry-After before succeeding."""
+    rate_limited = _make_response(status=403, headers={"Retry-After": "2"})
+    success = _make_response(status=200, json_value=[])
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("mcp_server.asyncio.sleep", sleep_mock)
+
+    async def _get(url: str, *, headers: dict[str, str]) -> MagicMock:  # noqa: ARG001
+        responses = getattr(_get, "_responses", [rate_limited, success])
+        if not responses:
+            raise AssertionError("No responses left for AsyncClient.get")
+        response = responses.pop(0)
+        _get._responses = responses
+        return response
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = _get
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_pr_comments("owner", "repo", 1)
+
+    assert result == []
+    sleep_mock.assert_awaited_once()
+    assert sleep_mock.await_args.args[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_comments_rate_limit_uses_reset_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rate_limited = _make_response(
+        status=403,
+        headers={"X-RateLimit-Reset": "1005", "X-RateLimit-Remaining": "0"},
+    )
+    success = _make_response(status=200, json_value=[])
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("mcp_server.asyncio.sleep", sleep_mock)
+    monkeypatch.setenv("GITHUB_TOKEN", "token123")
+    monkeypatch.setattr("time.time", lambda: 1000.0)
+
+    async def _get(url: str, *, headers: dict[str, str]) -> MagicMock:  # noqa: ARG001
+        responses = getattr(_get, "_responses", [rate_limited, success])
+        response = responses.pop(0)
+        _get._responses = responses
+        return response
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = _get
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+        await fetch_pr_comments("owner", "repo", 1)
+
+    sleep_mock.assert_awaited_once()
+    assert sleep_mock.await_args.args[0] == 5
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_comments_rate_limit_invalid_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    rate_limited = _make_response(status=429, headers={"Retry-After": "not-a-number"})
+    success = _make_response(status=200, json_value=[])
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("mcp_server.asyncio.sleep", sleep_mock)
+
+    async def _get(url: str, *, headers: dict[str, str]) -> MagicMock:  # noqa: ARG001
+        responses = getattr(_get, "_responses", [rate_limited, success])
+        response = responses.pop(0)
+        _get._responses = responses
+        return response
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = _get
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+        await fetch_pr_comments("owner", "repo", 1)
+
+    sleep_mock.assert_awaited_once()
+    assert sleep_mock.await_args.args[0] == 60
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_comments_returns_none_when_server_error_exhausts_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Should return None when 5xx responses exhaust retries."""
+    request = httpx.Request("GET", "https://api.github.com")
+    http_error = httpx.HTTPStatusError(
+        "Server error",
+        request=request,
+        response=httpx.Response(500, request=request),
+    )
+    server_error = _make_response(status=500, raise_error=http_error)
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [server_error]
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_pr_comments("owner", "repo", 1, max_retries=0)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_comments_returns_none_for_invalid_payload() -> None:
+    """Should return None when the response payload is not a list."""
+    invalid_payload = _make_response(status=200, json_value={"message": "oops"})
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [invalid_payload]
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_pr_comments("owner", "repo", 1)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_comments_handles_timeout_exception() -> None:
+    """Should return None when httpx raises a TimeoutException."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client.get.side_effect = httpx.TimeoutException("timeout")
+
+    with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_pr_comments("owner", "repo", 1)
+
+    assert result is None

--- a/tests/test_rest_error_handling.py
+++ b/tests/test_rest_error_handling.py
@@ -28,7 +28,9 @@ def _make_response(
 
 
 @pytest.mark.asyncio
-async def test_fetch_pr_comments_token_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_fetch_pr_comments_token_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Should retry with classic token scheme after a 401 using Bearer."""
     monkeypatch.setenv("GITHUB_TOKEN", "token123")
 
@@ -61,7 +63,9 @@ async def test_fetch_pr_comments_token_fallback(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
-async def test_fetch_pr_comments_rate_limit_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_fetch_pr_comments_rate_limit_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Should back off on 403 responses with Retry-After before succeeding."""
     rate_limited = _make_response(status=403, headers={"Retry-After": "2"})
     success = _make_response(status=200, json_value=[])
@@ -124,7 +128,9 @@ async def test_fetch_pr_comments_rate_limit_uses_reset_header(
 
 
 @pytest.mark.asyncio
-async def test_fetch_pr_comments_rate_limit_invalid_header(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_fetch_pr_comments_rate_limit_invalid_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     rate_limited = _make_response(status=429, headers={"Retry-After": "not-a-number"})
     success = _make_response(status=200, json_value=[])
 


### PR DESCRIPTION
## Summary
- enable Ruff BLE001 so broad exception catches are lint failures
- replace blanket exception handlers with targeted error handling in server, resolver, and scripts
- update mocks/tests to align with new exception behavior and keep coverage

## Testing
- uv run ruff check .
- uv run pytest -q