### PR TITLE
perf: optimize generate_markdown concatenation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ mcp-github-pr-review = "mcp_github_pr_review.cli:main"
 [project.optional-dependencies]
 dev = [
     "pytest>=8.4.1",
+    "pytest-benchmark>=4.0.0",
     "pytest-asyncio>=1.1.0",
     "pytest-timeout>=2.3.1",
     "pytest-cov>=6.0.0",
@@ -168,6 +169,7 @@ ignore_missing_imports = true
 [dependency-groups]
 dev = [
     "pytest>=8.4.1",
+    "pytest-benchmark>=4.0.0",
     "pytest-asyncio>=1.1.0",
     "pytest-timeout>=2.3.1",
     "pytest-cov>=6.0.0",

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -674,9 +674,10 @@ def generate_markdown(comments: Sequence[CommentResult]) -> str:
                 current = 0
         return "`" * max(minimum, longest_run + 1)
 
-    markdown = "# Pull Request Review Comments\n\n"
+    parts: list[str] = ["# Pull Request Review Comments\n\n"]
     if not comments:
-        return markdown + "No comments found.\n"
+        parts.append("No comments found.\n")
+        return "".join(parts)
 
     for comment in comments:
         # Skip error messages - they are not review comments
@@ -689,15 +690,15 @@ def generate_markdown(comments: Sequence[CommentResult]) -> str:
         user_data = comment.get("user")
         login = user_data.get("login", "N/A") if isinstance(user_data, dict) else "N/A"
         username = escape_html_safe(login)
-        markdown += f"## Review Comment by {username}\n\n"
+        parts.append(f"## Review Comment by {username}\n\n")
 
         # Escape file path - inside backticks but could break out
         file_path = escape_html_safe(comment.get("path", "N/A"))
-        markdown += f"**File:** `{file_path}`\n"
+        parts.append(f"**File:** `{file_path}`\n")
 
         # Line number is typically safe but escape for consistency
         line_num = escape_html_safe(comment.get("line", "N/A"))
-        markdown += f"**Line:** {line_num}\n"
+        parts.append(f"**Line:** {line_num}\n")
 
         # Add status indicators if available
         status_parts = []
@@ -717,25 +718,25 @@ def generate_markdown(comments: Sequence[CommentResult]) -> str:
             status_parts.append("⚠ Outdated")
 
         if status_parts:
-            markdown += f"**Status:** {' | '.join(status_parts)}\n"
+            parts.append(f"**Status:** {' | '.join(status_parts)}\n")
 
-        markdown += "\n"
+        parts.append("\n")
 
         # Escape comment body to prevent XSS - this is the main attack vector
         body = escape_html_safe(comment.get("body", ""))
         body_fence = fence_for(body)
-        markdown += f"**Comment:**\n{body_fence}\n{body}\n{body_fence}\n\n"
+        parts.append(f"**Comment:**\n{body_fence}\n{body}\n{body_fence}\n\n")
 
         if "diff_hunk" in comment:
             # Escape diff content to prevent injection through malicious diffs
             diff_text = escape_html_safe(comment["diff_hunk"])
             diff_fence = fence_for(diff_text)
             # Language hint remains after the opening fence
-            markdown += (
+            parts.append(
                 f"**Code Snippet:**\n{diff_fence}diff\n{diff_text}\n{diff_fence}\n\n"
             )
-        markdown += "---\n\n"
-    return markdown
+        parts.append("---\n\n")
+    return "".join(parts)
 
 
 T = TypeVar("T")

--- a/tests/benchmarks/test_generate_markdown_bench.py
+++ b/tests/benchmarks/test_generate_markdown_bench.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from mcp_github_pr_review.server import CommentResult, generate_markdown
+
+
+class _User(TypedDict, total=False):
+    login: str
+
+
+class _Comment(TypedDict, total=False):
+    user: _User
+    path: str
+    line: int
+    body: str
+    diff_hunk: str
+    is_resolved: bool
+    is_outdated: bool
+    resolved_by: str | None
+
+
+def _build_comment_template() -> _Comment:
+    return _Comment(
+        user=_User(login="benchmark-user"),
+        path="src/example.py",
+        line=42,
+        body=(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+            "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+        ),
+        diff_hunk=(
+            "@@ -1,3 +1,3 @@\n"
+            "-old_value = 1\n"
+            "+new_value = 2\n"
+            " print('unchanged line')\n"
+        ),
+        is_resolved=False,
+        is_outdated=False,
+        resolved_by=None,
+    )
+
+
+def _build_comments(count: int) -> list[CommentResult]:
+    base_comment = _build_comment_template()
+    comments: list[CommentResult] = []
+    for idx in range(count):
+        comment: CommentResult = {
+            **base_comment,
+            "line": base_comment["line"] + idx,
+            "body": f"{base_comment['body']} (comment {idx})",
+            "diff_hunk": (
+                "@@ -1,3 +1,3 @@\n"
+                f"-old_value = {idx}\n"
+                f"+new_value = {idx + 1}\n"
+                " print('unchanged line')\n"
+            ),
+        }
+        comments.append(comment)
+    return comments
+
+
+LARGE_COMMENT_SET = _build_comments(750)
+
+
+def test_generate_markdown_benchmark(benchmark: Any) -> None:
+    result = benchmark(generate_markdown, LARGE_COMMENT_SET)
+    assert result.startswith("# Pull Request Review Comments")
+    assert "comment 0" in result
+    assert "comment 749" in result

--- a/uv.lock
+++ b/uv.lock
@@ -899,6 +899,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
     { name = "pytest-timeout" },
@@ -917,6 +918,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
     { name = "pytest-timeout" },
@@ -939,6 +941,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.1.0" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.32.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.1" },
@@ -959,6 +962,7 @@ dev = [
     { name = "pre-commit", specifier = ">=3.5.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
+    { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.32.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
@@ -1259,6 +1263,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -1434,6 +1447,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d0/a8bd08d641b393db3be3819b03e2d9bb8760ca8479080a26a5f6e540e99c/pytest-benchmark-5.1.0.tar.gz", hash = "sha256:9ea661cdc292e8231f7cd4c10b0319e56a2118e2c09d9f50e1b3d150d2aca105", size = 337810, upload-time = "2024-10-30T11:51:48.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/d6/b41653199ea09d5969d4e385df9bbfd9a100f28ca7e824ce7c0a016e3053/pytest_benchmark-5.1.0-py3-none-any.whl", hash = "sha256:922de2dfa3033c227c96da942d1878191afa135a29485fb942e85dff1c592c89", size = 44259, upload-time = "2024-10-30T11:51:45.94Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- build markdown via a list of parts and join once to avoid quadratic string concatenation
- add pytest-benchmark dependency plus `tests/benchmarks/test_generate_markdown_bench.py` to keep a reproducible perf harness
- confirm large-input behaviour still matches the previous version

## Testing
- `uv run pytest tests/benchmarks/test_generate_markdown_bench.py --benchmark-only`

## Benchmarks
- pytest-benchmark comparison against `0001_baseline-old`: mean improved from 3.8867 ms to 3.8176 ms (~1.8%) for 750 comments
- standalone micro-benchmark (5 runs each) across larger comment sets:
  - 2,000 comments: 10.86 ms → 10.37 ms (~4.5% faster)
  - 5,000 comments: 27.41 ms → 26.90 ms (~1.9% faster)
  - 10,000 comments: 54.22 ms → 51.77 ms (~4.5% faster)
  - 20,000 comments: 107.76 ms → 102.66 ms (~4.7% faster)
  - 40,000 comments: 219.44 ms → 206.96 ms (~5.7% faster)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pytest-benchmark dependency for comprehensive performance profiling and testing.

* **Tests**
  * Introduced performance benchmark tests for markdown generation with large datasets.

* **Refactor**
  * Optimized markdown generation processing mechanism for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->