### PR TITLE
[codex] add PR thread resolution tool and prompt trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ Resolves a GitHub review thread when an issue has been fixed by an agent.
     -   `host` (str, optional): Override GitHub host for enterprise instances.
     -   `max_retries` (int, optional): Retry budget for transient network/API failures.
 -   **Returns:**
-    -   A JSON object containing `thread_id`, `is_resolved`, and `resolved_by` when available.
+    -   A JSON-formatted string (text), produced via `json.dumps(...)`, not a native JSON object.
+    -   When parsed as JSON, the payload contains `thread_id`, `is_resolved`, and `resolved_by` when available.
 
 ### GitHub Token Scopes
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Fetches all review comments from a given GitHub pull request URL. The tool retur
     -   When `output="markdown"` (default): a single text item containing Markdown.
     -   When `output="json"`: a single text item containing a JSON string with the raw comments list.
     -   When `output="both"`: two text items in order — first JSON, then Markdown.
+    -   GraphQL results include `thread_id` so resolved comments can be closed later with `resolve_pr_review_thread`.
 
 Example (Markdown default):
 ```json
@@ -260,6 +261,17 @@ Resolves the open PR URL for the current branch using git detection.
     -   `branch` (str, optional): Override branch name for PR resolution.
 -   **Returns:**
     -   The resolved PR URL as a string.
+
+### 3. `resolve_pr_review_thread(thread_id: str, host?: str, max_retries?: int) -> json`
+
+Resolves a GitHub review thread when an issue has been fixed by an agent.
+
+-   **Parameters:**
+    -   `thread_id` (str, required): GraphQL review thread ID (available in `fetch_pr_review_comments` output).
+    -   `host` (str, optional): Override GitHub host for enterprise instances.
+    -   `max_retries` (int, optional): Retry budget for transient network/API failures.
+-   **Returns:**
+    -   A JSON object containing `thread_id`, `is_resolved`, and `resolved_by` when available.
 
 ### GitHub Token Scopes
 

--- a/README.md
+++ b/README.md
@@ -273,19 +273,25 @@ Resolves a GitHub review thread when an issue has been fixed by an agent.
 -   **Returns:**
     -   A JSON-formatted string (text), produced via `json.dumps(...)`, not a native JSON object.
     -   When parsed as JSON, the payload contains `thread_id`, `is_resolved`, and `resolved_by` when available.
+-   **Permissions:**
+    -   **Classic PAT:** `repo` scope (full repository access) is required.
+    -   **Fine-grained PAT:** Repository access to the target repo plus **Pull requests: Read and write**.
 
 ### GitHub Token Scopes
 
 Use least privilege for `GITHUB_TOKEN`:
 
+- Read-only tools (`fetch_pr_review_comments`, `resolve_open_pr_url`) can run with read-level pull request access.
 - Classic PATs:
-  - Public repositories: `public_repo` is sufficient.
-  - Private repositories: `repo` is required.
+  - Public repositories (read-only tools): `public_repo` is sufficient.
+  - Private repositories (read-only tools): `repo` is required.
+  - `resolve_pr_review_thread` (mutation): `repo` is required.
 - Fine-grained PATs:
   - Repository access: Select the target repo(s).
-  - Permissions: Pull requests → Read access (enables reading review comments at `GET /repos/{owner}/{repo}/pulls/{pull_number}/comments`).
+  - Read-only tools: Pull requests → Read access (enables reading review comments at `GET /repos/{owner}/{repo}/pulls/{pull_number}/comments`).
+  - `resolve_pr_review_thread`: Pull requests → Read and write.
 
-Avoid granting write or admin scopes unless needed for other tools.
+Avoid broader write/admin scopes unless needed by your workflow.
 
 ## Warning: Production Deployment
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Resolves the open PR URL for the current branch using git detection.
 -   **Returns:**
     -   The resolved PR URL as a string.
 
-### 3. `resolve_pr_review_thread(thread_id: str, host?: str, max_retries?: int) -> json`
+### 3. `resolve_pr_review_thread(thread_id: str, host?: str, max_retries?: int) -> str`
 
 Resolves a GitHub review thread when an issue has been fixed by an agent.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -35,7 +35,7 @@ Use the built-in health command to ensure connectivity:
 claude mcp call pr-review list-tools
 ```
 
-Expected response includes `fetch_pr_review_comments` and `resolve_open_pr_url`.
+Expected response includes `fetch_pr_review_comments`, `resolve_open_pr_url`, and `resolve_pr_review_thread`.
 
 ## Next Steps
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -26,6 +26,18 @@ Returns one or two text blocks depending on the `output` parameter. Markdown res
 
 String containing the PR URL, e.g. `https://github.com/cool-kids-inc/github-pr-review-mcp-server/pull/42`.
 
+## `resolve_pr_review_thread`
+
+- **Description**: Resolve a GitHub pull request review thread once the requested issue has been fixed.
+- **Parameters**:
+  - `thread_id` (string, required): GraphQL review thread ID (returned as `thread_id` from `fetch_pr_review_comments`).
+  - `host` (string, optional): GitHub host override for enterprise instances.
+  - `max_retries` (int, optional): Retry budget for transient HTTP failures.
+
+### Response
+
+JSON string with resolution details, including `thread_id`, `is_resolved`, and `resolved_by` when available.
+
 ## Error Codes
 
 | Code | Description | Recommended Action |

--- a/src/mcp_github_pr_review/mcp.json
+++ b/src/mcp_github_pr_review/mcp.json
@@ -6,7 +6,7 @@
   "args": [],
   "env": {
     "GITHUB_TOKEN": {
-      "description": "GitHub personal access token with pull-request read access (public_repo or repo scope).",
+      "description": "GitHub personal access token. With prompts/thread resolution enabled, resolve_pr_review_thread (GraphQL resolveReviewThread mutation) requires write-capable permissions and will fail with a read-only token. Required scopes: classic PAT repo (full access); fine-grained PAT Pull requests: Read & write.",
       "required": true
     },
     "GH_HOST": {

--- a/src/mcp_github_pr_review/mcp.json
+++ b/src/mcp_github_pr_review/mcp.json
@@ -24,6 +24,6 @@
   "capabilities": {
     "tools": true,
     "resources": false,
-    "prompts": false
+    "prompts": true
   }
 }

--- a/src/mcp_github_pr_review/models.py
+++ b/src/mcp_github_pr_review/models.py
@@ -96,6 +96,7 @@ class ReviewCommentModel(BaseModel):
         line: Line number (0 for file-level comments)
         body: Comment text
         diff_hunk: Diff context
+        thread_id: GraphQL review thread ID (required to resolve thread)
         is_resolved: Whether comment is resolved
         is_outdated: Whether comment is outdated
         resolved_by: Username of resolver, if resolved
@@ -112,6 +113,7 @@ class ReviewCommentModel(BaseModel):
     line: int = Field(default=0, ge=0)
     body: str = Field(default="")
     diff_hunk: str = Field(default="")
+    thread_id: str | None = None
     is_resolved: bool = False
     is_outdated: bool = False
     resolved_by: str | None = None
@@ -153,6 +155,7 @@ class ReviewCommentModel(BaseModel):
             line=data.get("line") or 0,
             body=body,
             diff_hunk=data.get("diff_hunk", ""),
+            thread_id=data.get("thread_id"),
             is_resolved=data.get("is_resolved", False),
             is_outdated=data.get("is_outdated", False),
             resolved_by=data.get("resolved_by"),
@@ -183,6 +186,7 @@ class ReviewCommentModel(BaseModel):
             line=node.get("line") or 0,
             body=node.get("body", ""),
             diff_hunk=node.get("diffHunk", ""),
+            thread_id=node.get("threadId"),
             is_resolved=node.get("isResolved", False),
             is_outdated=node.get("isOutdated", False),
             resolved_by=resolved_by,
@@ -243,3 +247,24 @@ class ResolveOpenPrUrlArgs(BaseModel):
     repo: str | None = None
     branch: str | None = None
     select_strategy: Literal["branch", "latest", "first", "error"] = "branch"
+
+
+class ResolvePRReviewThreadArgs(BaseModel):
+    """Arguments for the resolve_pr_review_thread MCP tool."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    thread_id: str = Field(min_length=1)
+    host: str | None = None
+    max_retries: int | None = Field(default=None, ge=0, le=10)
+
+    @field_validator("thread_id")
+    @classmethod
+    def _strip_thread_id(cls, v: str) -> str:
+        thread_id = v.strip()
+        if not thread_id:
+            raise ValueError("thread_id must not be empty")
+        return thread_id

--- a/src/mcp_github_pr_review/models.py
+++ b/src/mcp_github_pr_review/models.py
@@ -261,6 +261,18 @@ class ResolvePRReviewThreadArgs(BaseModel):
     host: str | None = None
     max_retries: int | None = Field(default=None, ge=0, le=10)
 
+    @field_validator("max_retries", mode="before")
+    @classmethod
+    def _reject_bool_and_float(cls, v: Any) -> Any:
+        """Reject boolean and float values for numeric fields."""
+        if v is None:
+            return v
+        if isinstance(v, bool):
+            raise ValueError("Invalid type: expected integer")
+        if isinstance(v, float):
+            raise ValueError("Invalid type: expected integer")
+        return v
+
     @field_validator("thread_id")
     @classmethod
     def _strip_thread_id(cls, v: str) -> str:

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -21,6 +21,10 @@ from mcp import server
 from mcp.server.lowlevel.server import NotificationOptions
 from mcp.server.models import InitializationOptions
 from mcp.types import (
+    GetPromptResult,
+    Prompt,
+    PromptArgument,
+    PromptMessage,
     TextContent,
     Tool,
 )
@@ -40,6 +44,7 @@ from .github_api_constants import (
 from .models import (
     FetchPRReviewCommentsArgs,
     ResolveOpenPrUrlArgs,
+    ResolvePRReviewThreadArgs,
     ReviewCommentModel,
 )
 
@@ -536,6 +541,7 @@ async def fetch_pr_comments_graphql(
               endCursor
             }
             nodes {
+              id
               isResolved
               isOutdated
               resolvedBy {
@@ -643,6 +649,7 @@ async def fetch_pr_comments_graphql(
                     if len(all_comments) >= max_comments_v:
                         limit_reached = True
                         break
+                    thread_id = thread.get("id")
                     is_resolved = thread.get("isResolved", False)
                     is_outdated = thread.get("isOutdated", False)
                     resolved_by_data = thread.get("resolvedBy")
@@ -655,6 +662,7 @@ async def fetch_pr_comments_graphql(
                         # Build a complete node dict with thread-level metadata
                         node = {
                             **comment,
+                            "threadId": thread_id,
                             "isResolved": is_resolved,
                             "isOutdated": is_outdated,
                             "resolvedBy": resolved_by_data,
@@ -944,6 +952,118 @@ async def fetch_pr_comments(
         raise
 
 
+async def resolve_pr_review_thread(
+    thread_id: str,
+    *,
+    host: str = "github.com",
+    max_retries: int | None = None,
+) -> dict[str, Any]:
+    """Resolve a GitHub PR review thread via GraphQL.
+
+    Args:
+        thread_id: GraphQL review thread node ID.
+        host: GitHub host to target (e.g., github.com or GHES host).
+        max_retries: Optional transient retry override.
+
+    Returns:
+        Dictionary with resolved thread details.
+
+    Raises:
+        ValueError: Missing/invalid auth or GraphQL-level errors.
+        RuntimeError: Missing expected response shape.
+        httpx.RequestError/httpx.HTTPStatusError: Network/HTTP failures.
+    """
+    print(f"Resolving review thread {thread_id} on host {host}", file=sys.stderr)
+
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise ValueError("GITHUB_TOKEN is required to resolve review threads")
+
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {token}",
+        "Accept": GITHUB_ACCEPT_HEADER,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "Content-Type": "application/json",
+        "User-Agent": GITHUB_USER_AGENT,
+    }
+
+    max_retries_v = _int_conf("HTTP_MAX_RETRIES", 3, 0, 10, max_retries)
+
+    mutation = """
+    mutation($threadId: ID!) {
+      resolveReviewThread(input: {threadId: $threadId}) {
+        thread {
+          id
+          isResolved
+          resolvedBy {
+            login
+          }
+        }
+      }
+    }
+    """
+    variables = {"threadId": thread_id}
+
+    total_timeout = _float_conf("HTTP_TIMEOUT", 30.0, TIMEOUT_MIN, TIMEOUT_MAX)
+    connect_timeout = _float_conf(
+        "HTTP_CONNECT_TIMEOUT", 10.0, CONNECT_TIMEOUT_MIN, CONNECT_TIMEOUT_MAX
+    )
+
+    timeout = httpx.Timeout(timeout=total_timeout, connect=connect_timeout)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        rate_limit_handler = RateLimitHandler("resolve_pr_review_thread")
+        graphql_url = graphql_url_for_host(host)
+
+        async def make_graphql_request(
+            url: str = graphql_url, gql_vars: dict[str, Any] = variables
+        ) -> httpx.Response:
+            return await client.post(
+                url,
+                headers=headers,
+                json={"query": mutation, "variables": gql_vars},
+            )
+
+        async def handle_graphql_status(
+            resp: httpx.Response, _attempt: int
+        ) -> str | None:
+            return await rate_limit_handler.handle_rate_limit(resp)
+
+        try:
+            response = await _retry_http_request(
+                make_graphql_request,
+                max_retries_v,
+                status_handler=handle_graphql_status,
+            )
+        except SecondaryRateLimitError as exc:
+            raise RuntimeError(
+                "GitHub secondary rate limit while resolving review thread"
+            ) from exc
+
+        payload = response.json()
+        if "errors" in payload:
+            first_error = payload["errors"][0] if payload["errors"] else {}
+            error_message = first_error.get("message", "Unknown GraphQL error")
+            raise ValueError(
+                f"GitHub GraphQL error resolving review thread: {error_message}"
+            )
+
+        thread = payload.get("data", {}).get("resolveReviewThread", {}).get("thread")
+        if not isinstance(thread, dict):
+            raise RuntimeError("Missing resolveReviewThread.thread in GraphQL response")
+
+        resolved_by_data = thread.get("resolvedBy")
+        resolved_by = (
+            resolved_by_data.get("login")
+            if isinstance(resolved_by_data, dict)
+            else None
+        )
+        return {
+            "thread_id": thread.get("id", thread_id),
+            "is_resolved": bool(thread.get("isResolved", False)),
+            "resolved_by": resolved_by,
+        }
+
+
 def generate_markdown(comments: Sequence[CommentResult]) -> str:
     """Generates a markdown string from a list of review comments."""
 
@@ -984,6 +1104,10 @@ def generate_markdown(comments: Sequence[CommentResult]) -> str:
         # Line number is typically safe but escape for consistency
         line_num = escape_html_safe(comment.get("line", "N/A"))
         markdown += f"**Line:** {line_num}\n"
+
+        thread_id = comment.get("thread_id")
+        if thread_id:
+            markdown += f"**Thread ID:** `{escape_html_safe(thread_id)}`\n"
 
         # Add status indicators if available
         status_parts = []
@@ -1041,6 +1165,92 @@ class PRReviewServer:
         # in "Method not found" errors from clients.
         self.server.list_tools()(self.handle_list_tools)  # type: ignore[no-untyped-call]
         self.server.call_tool()(self.handle_call_tool)
+        self.server.list_prompts()(self.handle_list_prompts)  # type: ignore[no-untyped-call]
+        self.server.get_prompt()(self.handle_get_prompt)  # type: ignore[no-untyped-call]
+
+    async def handle_list_prompts(self) -> list[Prompt]:
+        """List available prompts for agent workflows."""
+        return [
+            Prompt(
+                name="resolve_pr_comment_after_fix",
+                description=(
+                    "Trigger this when an agent has implemented feedback and the PR "
+                    "review thread should be marked resolved."
+                ),
+                arguments=[
+                    PromptArgument(
+                        name="thread_id",
+                        description=(
+                            "GraphQL review thread ID to resolve (available in "
+                            "fetch_pr_review_comments output as thread_id)."
+                        ),
+                        required=True,
+                    ),
+                    PromptArgument(
+                        name="host",
+                        description=(
+                            "Optional GitHub host override (for example github.com or "
+                            "an enterprise hostname)."
+                        ),
+                        required=False,
+                    ),
+                    PromptArgument(
+                        name="summary",
+                        description=(
+                            "Optional one-line summary of what was fixed before "
+                            "resolving the thread."
+                        ),
+                        required=False,
+                    ),
+                ],
+            )
+        ]
+
+    async def handle_get_prompt(
+        self, name: str, arguments: dict[str, str] | None
+    ) -> GetPromptResult:
+        """Return prompt content by name."""
+        if name != "resolve_pr_comment_after_fix":
+            raise ValueError(f"Unknown prompt: {name}")
+
+        prompt_args = arguments or {}
+        thread_id = prompt_args.get("thread_id", "").strip()
+        host = prompt_args.get("host", "").strip()
+        summary = prompt_args.get("summary", "").strip()
+
+        lines = [
+            "The implementation work is complete and this PR feedback is resolved."
+        ]
+        if summary:
+            lines.append(f"Fix summary: {summary}")
+
+        if thread_id:
+            tool_call = f'Use `resolve_pr_review_thread` with `thread_id="{thread_id}"`'
+            if host:
+                tool_call += f' and `host="{host}"`.'
+            else:
+                tool_call += "."
+            lines.append(tool_call)
+        else:
+            lines.append(
+                "First call `fetch_pr_review_comments`, capture the relevant "
+                "`thread_id`, then call `resolve_pr_review_thread`."
+            )
+
+        lines.append(
+            "Only resolve the thread after verifying the requested changes "
+            "are actually complete."
+        )
+
+        return GetPromptResult(
+            description="Resolve a PR review thread after a fix is complete.",
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(type="text", text="\n".join(lines)),
+                )
+            ],
+        )
 
     async def handle_list_tools(self) -> list[Tool]:
         """
@@ -1172,6 +1382,43 @@ class PRReviewServer:
                     },
                 },
             ),
+            Tool(
+                name="resolve_pr_review_thread",
+                description=(
+                    "Resolves a GitHub pull request review thread when an issue has "
+                    "been fixed. Requires a GraphQL review thread ID (thread_id), "
+                    "which is available from fetch_pr_review_comments output."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "thread_id": {
+                            "type": "string",
+                            "description": (
+                                "GraphQL review thread ID to resolve "
+                                "(for example PRT_kwDO... )."
+                            ),
+                        },
+                        "host": {
+                            "type": "string",
+                            "description": (
+                                "GitHub host override (e.g., 'github.com' or "
+                                "'github.enterprise.com'). If omitted, "
+                                "detected from git context or defaults to github.com."
+                            ),
+                        },
+                        "max_retries": {
+                            "type": "integer",
+                            "description": (
+                                "Max retries for transient errors (server-capped)."
+                            ),
+                            "minimum": 0,
+                            "maximum": 10,
+                        },
+                    },
+                    "required": ["thread_id"],
+                },
+            ),
         ]
 
     async def handle_call_tool(
@@ -1182,12 +1429,14 @@ class PRReviewServer:
 
         Parameters:
             name (str): The tool identifier to invoke (e.g.,
-                "fetch_pr_review_comments", "resolve_open_pr_url").
+                "fetch_pr_review_comments", "resolve_open_pr_url",
+                "resolve_pr_review_thread").
             arguments (dict[str, Any]): Tool-specific arguments; expected keys
                 depend on `name` (for example, "pr_url", "per_page",
                 "max_pages", "max_comments", "max_retries",
                 "select_strategy", "owner", "repo", "branch", and "output" for
-                "fetch_pr_review_comments").
+                "fetch_pr_review_comments"; "thread_id", "host", "max_retries"
+                for "resolve_pr_review_thread").
 
         Returns:
             Sequence[TextContent]: One or more text outputs produced by the
@@ -1368,6 +1617,49 @@ class PRReviewServer:
                 )
             )
             return [TextContent(type="text", text=resolved_url)]
+
+        if name == "resolve_pr_review_thread":
+            try:
+                validated_args_thread = ResolvePRReviewThreadArgs.model_validate(
+                    arguments
+                )
+            except ValidationError as e:
+                errors = e.errors()
+                if errors:
+                    first_error = errors[0]
+                    field = first_error["loc"][0] if first_error["loc"] else "unknown"
+                    msg = first_error["msg"]
+                    error_type = first_error["type"]
+                    if "int_parsing" in error_type or "int_type" in error_type:
+                        raise ValueError(
+                            f"Invalid type for {field}: expected integer"
+                        ) from None
+                    if (
+                        "greater_than_equal" in error_type
+                        or "less_than_equal" in error_type
+                    ):
+                        raise ValueError(
+                            f"Invalid value for {field}: must be between 0 and 10"
+                        ) from None
+                    raise ValueError(f"Invalid value for {field}: {msg}") from None
+                raise ValueError("Invalid arguments") from None
+
+            args_dict_thread = validated_args_thread.model_dump(exclude_none=True)
+            host = args_dict_thread.get("host")
+            if not host:
+                try:
+                    host = git_detect_repo_branch().host
+                except (OSError, RuntimeError, ValueError):
+                    host = os.getenv("GH_HOST", "github.com")
+
+            resolution_result = await _run_with_handling(
+                lambda: resolve_pr_review_thread(
+                    thread_id=args_dict_thread["thread_id"],
+                    host=host or "github.com",
+                    max_retries=args_dict_thread.get("max_retries"),
+                )
+            )
+            return [TextContent(type="text", text=json.dumps(resolution_result))]
 
         raise ValueError(f"Unknown tool: {name}")
 

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -973,6 +973,16 @@ async def resolve_pr_review_thread(
         RuntimeError: Missing expected response shape.
         httpx.RequestError/httpx.HTTPStatusError: Network/HTTP failures.
     """
+    if not isinstance(thread_id, str):
+        raise ValueError(
+            "Invalid thread_id: must be a non-empty, non-whitespace string"
+        )
+    normalized_thread_id = thread_id.strip()
+    if not normalized_thread_id:
+        raise ValueError(
+            "Invalid thread_id: must be a non-empty, non-whitespace string"
+        )
+
     normalized_host = host.strip().lower()
     if not normalized_host:
         normalized_host = os.getenv("GH_HOST", "github.com").strip().lower()
@@ -980,7 +990,7 @@ async def resolve_pr_review_thread(
         normalized_host = "github.com"
 
     print(
-        f"Resolving review thread {thread_id} on host {normalized_host}",
+        f"Resolving review thread {normalized_thread_id} on host {normalized_host}",
         file=sys.stderr,
     )
 
@@ -1011,7 +1021,7 @@ async def resolve_pr_review_thread(
       }
     }
     """
-    variables = {"threadId": thread_id}
+    variables = {"threadId": normalized_thread_id}
 
     total_timeout = _float_conf("HTTP_TIMEOUT", 30.0, TIMEOUT_MIN, TIMEOUT_MAX)
     connect_timeout = _float_conf(
@@ -1084,7 +1094,7 @@ async def resolve_pr_review_thread(
             else None
         )
         return {
-            "thread_id": thread.get("id", thread_id),
+            "thread_id": thread.get("id", normalized_thread_id),
             "is_resolved": bool(thread.get("isResolved", False)),
             "resolved_by": resolved_by,
         }

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -1404,7 +1404,7 @@ class PRReviewServer:
                             "type": "string",
                             "description": (
                                 "GraphQL review thread ID to resolve "
-                                "(for example PRT_kwDO... )."
+                                "(for example PRRT_kwDO... )."
                             ),
                         },
                         "host": {

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -1047,7 +1047,15 @@ async def resolve_pr_review_thread(
                 f"GitHub GraphQL error resolving review thread: {error_message}"
             )
 
-        thread = payload.get("data", {}).get("resolveReviewThread", {}).get("thread")
+        data = payload.get("data") or {}
+        if not isinstance(data, dict):
+            data = {}
+
+        resolve_review_thread = data.get("resolveReviewThread") or {}
+        if not isinstance(resolve_review_thread, dict):
+            resolve_review_thread = {}
+
+        thread = resolve_review_thread.get("thread")
         if not isinstance(thread, dict):
             raise RuntimeError("Missing resolveReviewThread.thread in GraphQL response")
 

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -973,7 +973,16 @@ async def resolve_pr_review_thread(
         RuntimeError: Missing expected response shape.
         httpx.RequestError/httpx.HTTPStatusError: Network/HTTP failures.
     """
-    print(f"Resolving review thread {thread_id} on host {host}", file=sys.stderr)
+    normalized_host = host.strip().lower()
+    if not normalized_host:
+        normalized_host = os.getenv("GH_HOST", "github.com").strip().lower()
+    if not normalized_host:
+        normalized_host = "github.com"
+
+    print(
+        f"Resolving review thread {thread_id} on host {normalized_host}",
+        file=sys.stderr,
+    )
 
     token = os.getenv("GITHUB_TOKEN")
     if not token:
@@ -1012,7 +1021,7 @@ async def resolve_pr_review_thread(
     timeout = httpx.Timeout(timeout=total_timeout, connect=connect_timeout)
     async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
         rate_limit_handler = RateLimitHandler("resolve_pr_review_thread")
-        graphql_url = graphql_url_for_host(host)
+        graphql_url = graphql_url_for_host(normalized_host)
 
         async def make_graphql_request(
             url: str = graphql_url, gql_vars: dict[str, Any] = variables
@@ -1040,8 +1049,17 @@ async def resolve_pr_review_thread(
             ) from exc
 
         payload = response.json()
-        if "errors" in payload:
-            first_error = payload["errors"][0] if payload["errors"] else {}
+        if not isinstance(payload, dict):
+            raise ValueError(
+                "Invalid GraphQL response format while resolving review thread: "
+                "expected top-level JSON object"
+            )
+
+        errors = payload.get("errors")
+        if errors:
+            first_error = errors[0] if isinstance(errors, list) else {}
+            if not isinstance(first_error, dict):
+                first_error = {}
             error_message = first_error.get("message", "Unknown GraphQL error")
             raise ValueError(
                 f"GitHub GraphQL error resolving review thread: {error_message}"

--- a/tests/test_graphql_error_handling.py
+++ b/tests/test_graphql_error_handling.py
@@ -1271,3 +1271,72 @@ async def test_resolve_pr_review_thread_graphql_error(
             match="GitHub GraphQL error resolving review thread: Thread not found",
         ):
             await resolve_pr_review_thread("PRRT_missing")
+
+
+@pytest.mark.asyncio
+async def test_resolve_pr_review_thread_rejects_non_dict_payload(
+    monkeypatch: pytest.MonkeyPatch, github_token: str
+) -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = ["not", "a", "dict"]
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Invalid GraphQL response format while resolving review thread: "
+                "expected top-level JSON object"
+            ),
+        ):
+            await resolve_pr_review_thread("PRRT_bad_payload")
+
+
+@pytest.mark.asyncio
+async def test_resolve_pr_review_thread_normalizes_host(
+    monkeypatch: pytest.MonkeyPatch, github_token: str
+) -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {
+            "resolveReviewThread": {
+                "thread": {
+                    "id": "PRRT_host123",
+                    "isResolved": True,
+                    "resolvedBy": {"login": "maintainer"},
+                }
+            }
+        }
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    captured_host: dict[str, str] = {}
+
+    def mock_graphql_url_for_host(host: str) -> str:
+        captured_host["value"] = host
+        return "https://example.com/api/graphql"
+
+    monkeypatch.setenv("GH_HOST", "  Enterprise.Example.com  ")
+    monkeypatch.setattr(
+        "mcp_github_pr_review.server.graphql_url_for_host",
+        mock_graphql_url_for_host,
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        await resolve_pr_review_thread("PRRT_host123", host="   ")
+
+    assert captured_host["value"] == "enterprise.example.com"

--- a/tests/test_graphql_error_handling.py
+++ b/tests/test_graphql_error_handling.py
@@ -1300,6 +1300,18 @@ async def test_resolve_pr_review_thread_rejects_non_dict_payload(
 
 
 @pytest.mark.asyncio
+async def test_resolve_pr_review_thread_rejects_empty_thread_id() -> None:
+    with patch("httpx.AsyncClient") as mock_client_class:
+        with pytest.raises(
+            ValueError,
+            match="Invalid thread_id: must be a non-empty, non-whitespace string",
+        ):
+            await resolve_pr_review_thread("   ")
+
+    mock_client_class.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_resolve_pr_review_thread_normalizes_host(
     monkeypatch: pytest.MonkeyPatch, github_token: str
 ) -> None:

--- a/tests/test_graphql_error_handling.py
+++ b/tests/test_graphql_error_handling.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from mcp_github_pr_review.server import fetch_pr_comments_graphql
+from mcp_github_pr_review.server import (
+    fetch_pr_comments_graphql,
+    resolve_pr_review_thread,
+)
 
 
 @pytest.mark.asyncio
@@ -1209,3 +1212,62 @@ async def test_graphql_empty_threads_do_not_affect_limit(
         assert result[59]["body"] == "Comment 60"
         assert result[60]["body"] == "Comment 61"
         assert result[109]["body"] == "Comment 110"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pr_review_thread_success(
+    monkeypatch: pytest.MonkeyPatch, github_token: str
+) -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {
+            "resolveReviewThread": {
+                "thread": {
+                    "id": "PRRT_abc123",
+                    "isResolved": True,
+                    "resolvedBy": {"login": "maintainer"},
+                }
+            }
+        }
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        result = await resolve_pr_review_thread("PRRT_abc123")
+
+        assert result["thread_id"] == "PRRT_abc123"
+        assert result["is_resolved"] is True
+        assert result["resolved_by"] == "maintainer"
+        assert mock_client.post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_pr_review_thread_graphql_error(
+    monkeypatch: pytest.MonkeyPatch, github_token: str
+) -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "errors": [{"message": "Thread not found"}],
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(
+            ValueError,
+            match="GitHub GraphQL error resolving review thread: Thread not found",
+        ):
+            await resolve_pr_review_thread("PRRT_missing")

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -39,6 +39,22 @@ def test_generate_markdown_skips_error_entries() -> None:
     assert "Review Comment by dev" in result
 
 
+def test_generate_markdown_includes_thread_id_when_available() -> None:
+    result = generate_markdown(
+        [
+            {
+                "user": {"login": "dev"},
+                "path": "file.py",
+                "line": 1,
+                "thread_id": "PRRT_thread123",
+                "body": "Looks good",
+                "diff_hunk": "@@\n+code\n",
+            }
+        ]
+    )
+    assert "**Thread ID:** `PRRT_thread123`" in result
+
+
 @pytest.mark.asyncio
 async def test_handle_list_tools(mcp_server: PRReviewServer) -> None:
     tools = await mcp_server.handle_list_tools()
@@ -46,6 +62,7 @@ async def test_handle_list_tools(mcp_server: PRReviewServer) -> None:
     assert {
         "fetch_pr_review_comments",
         "resolve_open_pr_url",
+        "resolve_pr_review_thread",
     } <= names
 
 
@@ -492,6 +509,80 @@ async def test_handle_call_tool_resolve_pr(
 
 
 @pytest.mark.asyncio
+async def test_handle_call_tool_resolve_pr_review_thread(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    resolve_thread_mock = AsyncMock(
+        return_value={
+            "thread_id": "PRRT_test123",
+            "is_resolved": True,
+            "resolved_by": "maintainer",
+        }
+    )
+    monkeypatch.setattr(
+        "mcp_github_pr_review.server.resolve_pr_review_thread", resolve_thread_mock
+    )
+
+    result = await mcp_server.handle_call_tool(
+        "resolve_pr_review_thread",
+        {"thread_id": "PRRT_test123", "host": "github.com", "max_retries": 2},
+    )
+
+    assert resolve_thread_mock.await_count == 1
+    await_kwargs = resolve_thread_mock.await_args.kwargs
+    assert await_kwargs["thread_id"] == "PRRT_test123"
+    assert await_kwargs["host"] == "github.com"
+    assert await_kwargs["max_retries"] == 2
+    assert json.loads(result[0].text)["is_resolved"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_resolve_pr_review_thread_uses_git_context_host(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    context = SimpleNamespace(
+        host="enterprise.example.com",
+        owner="ctx-owner",
+        repo="ctx-repo",
+        branch="ctx-branch",
+    )
+    monkeypatch.setattr(
+        "mcp_github_pr_review.server.git_detect_repo_branch", lambda: context
+    )
+    resolve_thread_mock = AsyncMock(
+        return_value={
+            "thread_id": "PRRT_ctx123",
+            "is_resolved": True,
+            "resolved_by": "maintainer",
+        }
+    )
+    monkeypatch.setattr(
+        "mcp_github_pr_review.server.resolve_pr_review_thread", resolve_thread_mock
+    )
+
+    await mcp_server.handle_call_tool(
+        "resolve_pr_review_thread",
+        {"thread_id": "PRRT_ctx123"},
+    )
+
+    await_kwargs = resolve_thread_mock.await_args.kwargs
+    assert await_kwargs["host"] == "enterprise.example.com"
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_resolve_pr_review_thread_invalid_max_retries(
+    mcp_server: PRReviewServer,
+) -> None:
+    with pytest.raises(ValueError, match="must be between 0 and 10"):
+        await mcp_server.handle_call_tool(
+            "resolve_pr_review_thread",
+            {"thread_id": "PRRT_test123", "max_retries": 11},
+        )
+
+
+@pytest.mark.asyncio
 async def test_handle_call_tool_resolve_pr_uses_git_context(
     monkeypatch: pytest.MonkeyPatch,
     mcp_server: PRReviewServer,
@@ -896,6 +987,34 @@ async def test_review_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_handle_list_prompts(mcp_server: PRReviewServer) -> None:
+    prompts = await mcp_server.handle_list_prompts()
+    names = {prompt.name for prompt in prompts}
+    assert "resolve_pr_comment_after_fix" in names
+
+
+@pytest.mark.asyncio
+async def test_handle_get_prompt_for_resolved_issue(mcp_server: PRReviewServer) -> None:
+    prompt = await mcp_server.handle_get_prompt(
+        "resolve_pr_comment_after_fix",
+        {
+            "thread_id": "PRRT_123",
+            "host": "github.com",
+            "summary": "Addressed edge-case handling",
+        },
+    )
+    assert "resolve_pr_review_thread" in prompt.messages[0].content.text
+    assert "PRRT_123" in prompt.messages[0].content.text
+    assert "Addressed edge-case handling" in prompt.messages[0].content.text
+
+
+@pytest.mark.asyncio
+async def test_handle_get_prompt_unknown_name(mcp_server: PRReviewServer) -> None:
+    with pytest.raises(ValueError, match="Unknown prompt"):
+        await mcp_server.handle_get_prompt("unknown_prompt", {})
+
+
+@pytest.mark.asyncio
 async def test_resolve_open_pr_url_tool_schema_includes_host(
     mcp_server: PRReviewServer,
 ) -> None:
@@ -1043,3 +1162,17 @@ async def test_handle_call_tool_resolve_pr_explicit_host_overrides_git_context(
     await_kwargs = resolve_mock.await_args.kwargs
     assert await_kwargs["host"] == "override-host.com"
     assert result[0].text == "https://override-host.com/git-owner/git-repo/pull/55"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pr_review_thread_tool_schema(
+    mcp_server: PRReviewServer,
+) -> None:
+    tools = await mcp_server.handle_list_tools()
+    resolve_tool = next(t for t in tools if t.name == "resolve_pr_review_thread")
+
+    properties = resolve_tool.inputSchema["properties"]
+    assert "thread_id" in properties
+    assert properties["thread_id"]["type"] == "string"
+    assert "max_retries" in properties
+    assert resolve_tool.inputSchema["required"] == ["thread_id"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,7 @@ from mcp_github_pr_review.models import (
     GitContextModel,
     GitHubUserModel,
     ResolveOpenPrUrlArgs,
+    ResolvePRReviewThreadArgs,
     ReviewCommentModel,
 )
 
@@ -315,6 +316,7 @@ class TestReviewCommentModel:
     def test_from_graphql_with_complete_data(self) -> None:
         """Test from_graphql() with complete GraphQL node data."""
         graphql_node = {
+            "threadId": "PRRT_thread123",
             "author": {"login": "octocat"},
             "path": "src/app.py",
             "line": 100,
@@ -330,6 +332,7 @@ class TestReviewCommentModel:
         assert comment.line == 100
         assert comment.body == "Nice work!"
         assert comment.diff_hunk == "@@ -98,3 +98,3 @@"
+        assert comment.thread_id == "PRRT_thread123"
         assert comment.is_resolved is True
         assert comment.is_outdated is False
         assert comment.resolved_by == "maintainer"
@@ -663,3 +666,34 @@ class TestResolveOpenPrUrlArgs:
         with pytest.raises(ValidationError) as exc_info:
             ResolveOpenPrUrlArgs(extra_field="value")  # type: ignore
         assert "Extra inputs are not permitted" in str(exc_info.value)
+
+
+class TestResolvePRReviewThreadArgs:
+    """Tests for ResolvePRReviewThreadArgs."""
+
+    def test_creates_with_required_thread_id(self) -> None:
+        args = ResolvePRReviewThreadArgs(thread_id="PRRT_123")
+        assert args.thread_id == "PRRT_123"
+        assert args.host is None
+        assert args.max_retries is None
+
+    def test_strips_thread_id_whitespace(self) -> None:
+        args = ResolvePRReviewThreadArgs(thread_id="  PRRT_123  ")
+        assert args.thread_id == "PRRT_123"
+
+    def test_rejects_empty_thread_id(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ResolvePRReviewThreadArgs(thread_id="   ")
+        assert "thread_id must not be empty" in str(exc_info.value)
+
+    def test_validates_max_retries_range(self) -> None:
+        args = ResolvePRReviewThreadArgs(thread_id="PRRT_123", max_retries=3)
+        assert args.max_retries == 3
+
+        with pytest.raises(ValidationError) as exc_info:
+            ResolvePRReviewThreadArgs(thread_id="PRRT_123", max_retries=-1)
+        assert "Input should be greater than or equal to 0" in str(exc_info.value)
+
+        with pytest.raises(ValidationError) as exc_info:
+            ResolvePRReviewThreadArgs(thread_id="PRRT_123", max_retries=11)
+        assert "Input should be less than or equal to 10" in str(exc_info.value)


### PR DESCRIPTION
## Summary
This change adds first-class support for resolving GitHub pull request review threads from this MCP server, and adds a companion prompt that agents can use when they have completed a requested fix.

Before this change, agents could fetch and format review comments but had no built-in tool to mark a thread as resolved once the issue was addressed. That gap forced users to resolve threads manually in GitHub UI or use an external tool, which interrupted automated review workflows.

## Problem and User Impact
Users running agentic PR review workflows could identify unresolved comments but could not complete the lifecycle in the same MCP server. The practical effect was that implementation could be done by the agent, but closure of review feedback still required manual follow-up. This made automated workflows slower and less consistent, especially when handling many comments.

## Root Cause
The server exposed tools for reading review state (`fetch_pr_review_comments`) and resolving PR URLs (`resolve_open_pr_url`) but did not expose a mutation-capable tool for thread resolution. In addition, fetched comment output did not include a review thread identifier, so there was no direct token to pass into a resolver even if one existed.

## Fix
The change introduces a new tool, `resolve_pr_review_thread`, backed by GitHub GraphQL `resolveReviewThread` mutation with existing retry, timeout, and rate-limit handling patterns.

It also extends comment modeling and GraphQL fetch transformation to carry `thread_id`, and includes that ID in generated markdown output so agents can directly connect comment feedback to a resolve operation.

Prompt support is now registered and enabled in manifest capabilities, including a new prompt `resolve_pr_comment_after_fix`. The prompt is designed to trigger when an issue is resolved by an agent and explicitly instructs use of `resolve_pr_review_thread` with the relevant `thread_id`.

Documentation and tests were updated to reflect the new tool and prompt capability.

## Validation
The following checks were run locally and passed:

- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run mypy .`
- `make compile-check`
- `uv run pytest` (`391 passed, 2 skipped`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to resolve GitHub PR review threads, surfaced thread IDs in PR review comments, and show Thread ID in rendered markdown; prompts can drive resolution workflows.

* **Documentation**
  * Updated README, quickstart, and tool reference to document the new tool, parameters/returns, token permission requirements, prompt capability, and a production deployment warning.

* **Tests**
  * Added tests for thread resolution, GraphQL error handling, host normalization, validation, prompt/tool listings, and markdown Thread ID rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->