### PR TITLE
[codex] Add non-inline PR comments MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,43 @@ Example (JSON output):
 }
 ```
 
-### 2. `resolve_open_pr_url(select_strategy?: str, owner?: str, repo?: str, branch?: str) -> str`
+### 2. `fetch_pr_non_inline_comments`
+
+Fetches non-inline pull request conversation comments from a given GitHub pull request URL. The tool returns Markdown by default (optimized for human/AI readability), with options to request JSON or both.
+
+-   **Parameters:**
+    -   `pr_url` (str): The full URL of the pull request (e.g., `"https://github.com/owner/repo/pull/123"`). If omitted, the server will attempt to auto-resolve from the current repo/branch.
+    -   `output` (str, optional): Output format. One of `"markdown"` (default), `"json"`, or `"both"`.
+        - `markdown`: returns a single Markdown document rendered from the comments (default).
+        - `json`: returns a single JSON string with the raw comments list.
+        - `both`: returns two messages: first JSON, then Markdown.
+    -   `per_page` (int, optional): GitHub page size (1–100). Defaults from env `HTTP_PER_PAGE`.
+    -   `max_pages` (int, optional): Safety cap on pages. Defaults from env `PR_FETCH_MAX_PAGES`.
+    -   `max_comments` (int, optional): Safety cap on total comments. Defaults from env `PR_FETCH_MAX_COMMENTS`.
+    -   `max_retries` (int, optional): Retry budget for transient errors. Defaults from env `HTTP_MAX_RETRIES`.
+
+-   **Returns:**
+    -   When `output="markdown"` (default): a single text item containing Markdown.
+    -   When `output="json"`: a single text item containing a JSON string with the raw comments list.
+    -   When `output="both"`: two text items in order — first JSON, then Markdown.
+
+Example (Markdown default):
+```json
+{
+  "name": "fetch_pr_non_inline_comments",
+  "arguments": { "pr_url": "https://github.com/owner/repo/pull/123" }
+}
+```
+
+Example (JSON output):
+```json
+{
+  "name": "fetch_pr_non_inline_comments",
+  "arguments": { "pr_url": "https://github.com/owner/repo/pull/123", "output": "json" }
+}
+```
+
+### 3. `resolve_open_pr_url(select_strategy?: str, owner?: str, repo?: str, branch?: str) -> str`
 
 Resolves the open PR URL for the current branch using git detection.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -15,6 +15,21 @@
 
 Returns one or two text blocks depending on the `output` parameter. Markdown responses are formatted with review comment details including resolution status and code context.
 
+## `fetch_pr_non_inline_comments`
+
+- **Description**: Fetch non-inline pull request conversation comments (issue comments on the PR timeline) and render them as Markdown or JSON.
+- **Parameters**:
+  - `pr_url` (string, optional): Full PR URL. When omitted, auto-resolves from git metadata.
+  - `output` (enum): `"markdown"` (default), `"json"`, or `"both"`.
+  - `per_page` (int): Overrides pagination size. Defaults from `HTTP_PER_PAGE`.
+  - `max_pages` (int): Safety cap on pagination loops. Defaults from `PR_FETCH_MAX_PAGES`.
+  - `max_comments` (int): Hard limit on total comments collected. Defaults from `PR_FETCH_MAX_COMMENTS`.
+  - `max_retries` (int): Overrides HTTP retry budget. Defaults from `HTTP_MAX_RETRIES`.
+
+### Response
+
+Returns one or two text blocks depending on the `output` parameter. Markdown responses are formatted with comment author, timestamps, and body content.
+
 ## `resolve_open_pr_url`
 
 - **Description**: Resolve the open pull request that matches the current repository and branch.

--- a/src/mcp_github_pr_review/models.py
+++ b/src/mcp_github_pr_review/models.py
@@ -225,11 +225,8 @@ class NonInlineCommentModel(BaseModel):
         )
 
 
-class FetchPRReviewCommentsArgs(BaseModel):
-    """Arguments for the fetch_pr_review_comments MCP tool.
-
-    All numeric fields have server-enforced limits to prevent runaway operations.
-    """
+class _BaseFetchPRCommentsArgs(BaseModel):
+    """Shared arguments and validation for PR comment fetch tools."""
 
     model_config = ConfigDict(
         extra="forbid",
@@ -266,38 +263,15 @@ class FetchPRReviewCommentsArgs(BaseModel):
         return v
 
 
-class FetchPRNonInlineCommentsArgs(BaseModel):
+class FetchPRReviewCommentsArgs(_BaseFetchPRCommentsArgs):
+    """Arguments for the fetch_pr_review_comments MCP tool.
+
+    All numeric fields have server-enforced limits to prevent runaway operations.
+    """
+
+
+class FetchPRNonInlineCommentsArgs(_BaseFetchPRCommentsArgs):
     """Arguments for the fetch_pr_non_inline_comments MCP tool."""
-
-    model_config = ConfigDict(
-        extra="forbid",
-        validate_assignment=True,
-    )
-
-    pr_url: str | None = None
-    output: Literal["markdown", "json", "both"] = "markdown"
-    per_page: int | None = Field(default=None, ge=1, le=100)
-    max_pages: int | None = Field(default=None, ge=1, le=200)
-    max_comments: int | None = Field(default=None, ge=100, le=100000)
-    max_retries: int | None = Field(default=None, ge=0, le=10)
-    owner: str | None = None
-    repo: str | None = None
-    branch: str | None = None
-    select_strategy: Literal["branch", "latest", "first", "error"] = "branch"
-
-    @field_validator(
-        "per_page", "max_pages", "max_comments", "max_retries", mode="before"
-    )
-    @classmethod
-    def _reject_bool_and_float(cls, v: Any) -> Any:
-        """Reject boolean and float values for numeric fields."""
-        if v is None:
-            return v
-        if isinstance(v, bool):
-            raise ValueError("Invalid type: expected integer")
-        if isinstance(v, float):
-            raise ValueError("Invalid type: expected integer")
-        return v
 
 
 class ResolveOpenPrUrlArgs(BaseModel):

--- a/src/mcp_github_pr_review/models.py
+++ b/src/mcp_github_pr_review/models.py
@@ -189,6 +189,42 @@ class ReviewCommentModel(BaseModel):
         )
 
 
+class NonInlineCommentModel(BaseModel):
+    """Represents a non-inline pull request comment from the Issues API."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    id: int | str | None = None
+    user: GitHubUserModel
+    body: str = Field(default="")
+    created_at: str | None = None
+    updated_at: str | None = None
+    url: str | None = None
+    html_url: str | None = None
+    author_association: str | None = None
+
+    @classmethod
+    def from_rest(cls, data: dict[str, Any]) -> NonInlineCommentModel:
+        """Create a NonInlineCommentModel from REST API response data."""
+        user_data = data.get("user") or {}
+        user_login = user_data.get("login", "unknown")
+        body = data.get("body") or ""
+
+        return cls(
+            id=data.get("id"),
+            user=GitHubUserModel(login=user_login),
+            body=body,
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+            url=data.get("url"),
+            html_url=data.get("html_url"),
+            author_association=data.get("author_association"),
+        )
+
+
 class FetchPRReviewCommentsArgs(BaseModel):
     """Arguments for the fetch_pr_review_comments MCP tool.
 
@@ -221,6 +257,40 @@ class FetchPRReviewCommentsArgs(BaseModel):
         This mimics the behavior of the original _validate_int function.
         Runs before Pydantic's type coercion.
         """
+        if v is None:
+            return v
+        if isinstance(v, bool):
+            raise ValueError("Invalid type: expected integer")
+        if isinstance(v, float):
+            raise ValueError("Invalid type: expected integer")
+        return v
+
+
+class FetchPRNonInlineCommentsArgs(BaseModel):
+    """Arguments for the fetch_pr_non_inline_comments MCP tool."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    pr_url: str | None = None
+    output: Literal["markdown", "json", "both"] = "markdown"
+    per_page: int | None = Field(default=None, ge=1, le=100)
+    max_pages: int | None = Field(default=None, ge=1, le=200)
+    max_comments: int | None = Field(default=None, ge=100, le=100000)
+    max_retries: int | None = Field(default=None, ge=0, le=10)
+    owner: str | None = None
+    repo: str | None = None
+    branch: str | None = None
+    select_strategy: Literal["branch", "latest", "first", "error"] = "branch"
+
+    @field_validator(
+        "per_page", "max_pages", "max_comments", "max_retries", mode="before"
+    )
+    @classmethod
+    def _reject_bool_and_float(cls, v: Any) -> Any:
+        """Reject boolean and float values for numeric fields."""
         if v is None:
             return v
         if isinstance(v, bool):

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -743,26 +743,85 @@ async def fetch_pr_comments(
     max_retries: int | None = None,
 ) -> list[CommentResult] | None:
     """
-    Fetch and combine review comments for a pull request by iterating
-    the repository REST API pagination.
+    Fetch and combine inline review comments for a pull request via REST.
 
     Parameters:
-        per_page (int | None): Override for number of comments to
-            request per page.
-        max_pages (int | None): Override for maximum number of pages
-            to fetch.
-        max_comments (int | None): Override for a hard limit on total
-            comments to collect.
-        max_retries (int | None): Override for maximum retry attempts
-            on transient errors.
+        per_page (int | None): Override for number of comments to request per page.
+        max_pages (int | None): Override for maximum number of pages to fetch.
+        max_comments (int | None): Override for hard limit on total comments.
+        max_retries (int | None): Override for transient error retry count.
 
     Returns:
-        list[CommentResult] with comments combined from all fetched
-            pages, or `None` when fetching fails due to timeouts or
-            unrecoverable server errors.
+        list[CommentResult] or None when fetching fails/times out.
+    """
+
+    def _convert_review_comment(comment: dict[str, Any]) -> CommentResult:
+        return ReviewCommentModel.from_rest(comment).model_dump(exclude_none=True)
+
+    return await _fetch_pr_comments_rest_generic(
+        owner=owner,
+        repo=repo,
+        pull_number=pull_number,
+        host=host,
+        per_page=per_page,
+        max_pages=max_pages,
+        max_comments=max_comments,
+        max_retries=max_retries,
+        endpoint_template="/pulls/{pull_number}/comments",
+        context_name="fetch_pr_comments",
+        fetch_log_message="Fetching PR comments via REST",
+        page_log_message="Fetching REST API page",
+        success_log_message="Successfully fetched comments via REST",
+        timeout_log_message="Timeout fetching PR comments via REST",
+        request_error_log_message="Error fetching PR comments via REST",
+        comment_from_rest=_convert_review_comment,
+        emit_debug_page_count=True,
+    )
+
+
+async def _fetch_pr_comments_rest_generic(
+    owner: str,
+    repo: str,
+    pull_number: int,
+    *,
+    host: str = "github.com",
+    per_page: int | None = None,
+    max_pages: int | None = None,
+    max_comments: int | None = None,
+    max_retries: int | None = None,
+    endpoint_template: str,
+    context_name: str,
+    fetch_log_message: str,
+    page_log_message: str,
+    success_log_message: str,
+    timeout_log_message: str,
+    request_error_log_message: str,
+    comment_from_rest: Callable[[dict[str, Any]], CommentResult],
+    emit_debug_page_count: bool = False,
+) -> list[CommentResult] | None:
+    """
+    Generic REST fetcher for pull request comments with pagination and retries.
+
+    This powers both inline review comments and non-inline issue comments by
+    parameterizing endpoint path, model conversion, and log context.
+
+    Parameters:
+        endpoint_template: Path template such as
+            "/pulls/{pull_number}/comments" or "/issues/{pull_number}/comments".
+        context_name: Context string for RateLimitHandler and structured logs.
+        fetch_log_message: Initial fetch debug message.
+        page_log_message: Per-page debug message.
+        success_log_message: Success info message.
+        timeout_log_message: Timeout error message.
+        request_error_log_message: Request error message.
+        comment_from_rest: Converter from raw REST payload item to comment dict.
+        emit_debug_page_count: Whether to emit legacy page-count debug output.
+
+    Returns:
+        list[CommentResult] or None when fetching fails/times out.
     """
     logger.debug(
-        "Fetching PR comments via REST",
+        fetch_log_message,
         extra={"owner": owner, "repo": repo, "pull_number": pull_number},
     )
     token = os.getenv("GITHUB_TOKEN")
@@ -775,207 +834,6 @@ async def fetch_pr_comments(
         # Use Bearer prefix for fine-grained tokens
         headers["Authorization"] = f"Bearer {token}"
 
-    # URL-encode owner/repo to be safe, even though regex validation restricts format
-    safe_owner = quote(owner, safe="")
-    safe_repo = quote(repo, safe="")
-
-    # Load configurable limits from environment with safe defaults; allow per-call
-    # overrides
-    per_page_v = _int_conf("HTTP_PER_PAGE", 100, 1, 100, per_page)
-    max_pages_v = _int_conf("PR_FETCH_MAX_PAGES", 50, 1, 200, max_pages)
-    max_comments_v = _int_conf("PR_FETCH_MAX_COMMENTS", 2000, 100, 100000, max_comments)
-    max_retries_v = _int_conf("HTTP_MAX_RETRIES", 3, 0, 10, max_retries)
-
-    api_base = api_base_for_host(host)
-    base_url = (
-        f"{api_base}/repos/"
-        f"{safe_owner}/{safe_repo}/pulls/{pull_number}/comments?per_page={per_page_v}"
-    )
-    all_comments: list[CommentResult] = []
-    url: str | None = base_url
-    page_count = 0
-
-    # Load timeout configuration
-    total_timeout = _float_conf("HTTP_TIMEOUT", 30.0, TIMEOUT_MIN, TIMEOUT_MAX)
-    connect_timeout = _float_conf(
-        "HTTP_CONNECT_TIMEOUT", 10.0, CONNECT_TIMEOUT_MIN, CONNECT_TIMEOUT_MAX
-    )
-
-    try:
-        timeout = httpx.Timeout(timeout=total_timeout, connect=connect_timeout)
-        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
-            used_token_fallback = False
-            had_server_error = False
-            rate_limit_handler = RateLimitHandler("fetch_pr_comments")
-            while url:
-                logger.debug(
-                    "Fetching REST API page",
-                    extra={"page_number": page_count + 1, "url": url},
-                )
-
-                # Status handler for REST-specific logic (rate limiting, auth fallback)
-                async def handle_rest_status(
-                    resp: httpx.Response, _attempt: int
-                ) -> str | None:
-                    nonlocal used_token_fallback, had_server_error
-
-                    # Track 5xx errors for conservative failure behavior
-                    if 500 <= resp.status_code < 600:
-                        had_server_error = True
-
-                    # 401 Bearer token fallback
-                    if (
-                        resp.status_code == 401
-                        and token
-                        and not used_token_fallback
-                        and headers.get("Authorization", "").startswith("Bearer ")
-                    ):
-                        logger.warning(
-                            "401 Unauthorized with Bearer token; "
-                            "retrying with legacy token scheme",
-                            extra={
-                                "status_code": 401,
-                                "auth_fallback": "bearer_to_token",
-                            },
-                        )
-                        headers["Authorization"] = f"token {token}"
-                        used_token_fallback = True
-                        return "retry"
-
-                    # Rate limiting (delegated to RateLimitHandler)
-                    return await rate_limit_handler.handle_rate_limit(resp)
-
-                # Use retry helper with custom status handler (capture loop variable)
-                current_page_url = url  # Captured by while loop type narrowing
-
-                async def make_rest_request(
-                    page_url: str = current_page_url,
-                ) -> httpx.Response:
-                    return await client.get(page_url, headers=headers)
-
-                try:
-                    response = await _retry_http_request(
-                        make_rest_request,
-                        max_retries_v,
-                        status_handler=handle_rest_status,
-                    )
-                except SecondaryRateLimitError:
-                    # Logging already done in RateLimitHandler
-                    return None
-                except httpx.HTTPStatusError as e:
-                    # On exhausted 5xx retries, return None per test expectations
-                    if 500 <= e.response.status_code < 600:
-                        return None
-                    raise
-
-                # Conservative behavior: return None if any server error occurred,
-                # even if retry succeeded
-                if had_server_error:
-                    return None
-
-                # Process page
-                page_comments = response.json()
-                if not isinstance(page_comments, list) or not all(
-                    isinstance(c, dict) for c in page_comments
-                ):
-                    return None
-                # Convert REST comments using Pydantic model
-                for comment in page_comments:
-                    review_comment_model = ReviewCommentModel.from_rest(comment)
-                    all_comments.append(
-                        review_comment_model.model_dump(exclude_none=True)
-                    )
-                page_count += 1
-
-                # Enforce safety bounds to prevent unbounded memory/time use
-                print(
-                    "DEBUG: page_count="
-                    f"{page_count}, MAX_PAGES={max_pages_v}, "
-                    f"comments_len={len(all_comments)}",
-                    file=sys.stderr,
-                )
-                if page_count >= max_pages_v or len(all_comments) >= max_comments_v:
-                    print(
-                        "Reached safety limits for pagination; stopping early",
-                        file=sys.stderr,
-                    )
-                    break
-
-                # Check for next page using Link header
-                link_header = response.headers.get("Link")
-                next_url: str | None = None
-                if link_header:
-                    match = re.search(r"<([^>]+)>;\s*rel=\"next\"", link_header)
-                    next_url = match.group(1) if match else None
-                logger.debug("REST next page", extra={"next_url": next_url})
-                if next_url:
-                    url = next_url
-                else:
-                    break
-
-        total_comments = len(all_comments)
-        logger.info(
-            "Successfully fetched comments via REST",
-            extra={"total_comments": total_comments, "page_count": page_count},
-        )
-        return all_comments
-
-    except httpx.TimeoutException as e:
-        logger.error(
-            "Timeout fetching PR comments via REST",
-            extra={
-                "error": str(e),
-                "owner": owner,
-                "repo": repo,
-                "pull_number": pull_number,
-            },
-        )
-        traceback.print_exc(file=sys.stderr)
-        return None
-    except httpx.RequestError as e:
-        logger.error(
-            "Error fetching PR comments via REST",
-            extra={
-                "error": str(e),
-                "owner": owner,
-                "repo": repo,
-                "pull_number": pull_number,
-            },
-        )
-        traceback.print_exc(file=sys.stderr)
-        raise
-
-
-async def fetch_pr_non_inline_comments_rest(
-    owner: str,
-    repo: str,
-    pull_number: int,
-    *,
-    host: str = "github.com",
-    per_page: int | None = None,
-    max_pages: int | None = None,
-    max_comments: int | None = None,
-    max_retries: int | None = None,
-) -> list[CommentResult] | None:
-    """
-    Fetch non-inline pull request comments from the GitHub Issues API.
-
-    These are conversation-level comments on the PR itself (not code-line
-    review comments).
-    """
-    logger.debug(
-        "Fetching non-inline PR comments via REST",
-        extra={"owner": owner, "repo": repo, "pull_number": pull_number},
-    )
-    token = os.getenv("GITHUB_TOKEN")
-    headers: dict[str, str] = {
-        "Accept": GITHUB_ACCEPT_HEADER,
-        "X-GitHub-Api-Version": GITHUB_API_VERSION,
-        "User-Agent": GITHUB_USER_AGENT,
-    }
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-
     safe_owner = quote(owner, safe="")
     safe_repo = quote(repo, safe="")
 
@@ -987,7 +845,9 @@ async def fetch_pr_non_inline_comments_rest(
     api_base = api_base_for_host(host)
     base_url = (
         f"{api_base}/repos/"
-        f"{safe_owner}/{safe_repo}/issues/{pull_number}/comments?per_page={per_page_v}"
+        f"{safe_owner}/{safe_repo}"
+        f"{endpoint_template.format(pull_number=pull_number)}"
+        f"?per_page={per_page_v}"
     )
     all_comments: list[CommentResult] = []
     url: str | None = base_url
@@ -1003,10 +863,10 @@ async def fetch_pr_non_inline_comments_rest(
         async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             used_token_fallback = False
             had_server_error = False
-            rate_limit_handler = RateLimitHandler("fetch_pr_non_inline_comments")
+            rate_limit_handler = RateLimitHandler(context_name)
             while url:
                 logger.debug(
-                    "Fetching REST API page for non-inline comments",
+                    page_log_message,
                     extra={"page_number": page_count + 1, "url": url},
                 )
 
@@ -1068,12 +928,16 @@ async def fetch_pr_non_inline_comments_rest(
                     return None
 
                 for comment in page_comments:
-                    non_inline_comment_model = NonInlineCommentModel.from_rest(comment)
-                    all_comments.append(
-                        non_inline_comment_model.model_dump(exclude_none=True)
-                    )
+                    all_comments.append(comment_from_rest(comment))
                 page_count += 1
 
+                if emit_debug_page_count:
+                    print(
+                        "DEBUG: page_count="
+                        f"{page_count}, MAX_PAGES={max_pages_v}, "
+                        f"comments_len={len(all_comments)}",
+                        file=sys.stderr,
+                    )
                 if page_count >= max_pages_v or len(all_comments) >= max_comments_v:
                     print(
                         "Reached safety limits for pagination; stopping early",
@@ -1081,6 +945,7 @@ async def fetch_pr_non_inline_comments_rest(
                     )
                     break
 
+                # Check for next page using Link header
                 link_header = response.headers.get("Link")
                 next_url: str | None = None
                 if link_header:
@@ -1093,14 +958,14 @@ async def fetch_pr_non_inline_comments_rest(
                     break
 
         logger.info(
-            "Successfully fetched non-inline comments via REST",
+            success_log_message,
             extra={"total_comments": len(all_comments), "page_count": page_count},
         )
         return all_comments
 
     except httpx.TimeoutException as e:
         logger.error(
-            "Timeout fetching non-inline PR comments via REST",
+            timeout_log_message,
             extra={
                 "error": str(e),
                 "owner": owner,
@@ -1112,7 +977,7 @@ async def fetch_pr_non_inline_comments_rest(
         return None
     except httpx.RequestError as e:
         logger.error(
-            "Error fetching non-inline PR comments via REST",
+            request_error_log_message,
             extra={
                 "error": str(e),
                 "owner": owner,
@@ -1122,6 +987,47 @@ async def fetch_pr_non_inline_comments_rest(
         )
         traceback.print_exc(file=sys.stderr)
         raise
+
+
+async def fetch_pr_non_inline_comments_rest(
+    owner: str,
+    repo: str,
+    pull_number: int,
+    *,
+    host: str = "github.com",
+    per_page: int | None = None,
+    max_pages: int | None = None,
+    max_comments: int | None = None,
+    max_retries: int | None = None,
+) -> list[CommentResult] | None:
+    """
+    Fetch non-inline pull request comments from the GitHub Issues API.
+
+    These are conversation-level comments on the PR itself (not code-line
+    review comments).
+    """
+
+    def _convert_non_inline_comment(comment: dict[str, Any]) -> CommentResult:
+        return NonInlineCommentModel.from_rest(comment).model_dump(exclude_none=True)
+
+    return await _fetch_pr_comments_rest_generic(
+        owner=owner,
+        repo=repo,
+        pull_number=pull_number,
+        host=host,
+        per_page=per_page,
+        max_pages=max_pages,
+        max_comments=max_comments,
+        max_retries=max_retries,
+        endpoint_template="/issues/{pull_number}/comments",
+        context_name="fetch_pr_non_inline_comments",
+        fetch_log_message="Fetching non-inline PR comments via REST",
+        page_log_message="Fetching REST API page for non-inline comments",
+        success_log_message="Successfully fetched non-inline comments via REST",
+        timeout_log_message="Timeout fetching non-inline PR comments via REST",
+        request_error_log_message="Error fetching non-inline PR comments via REST",
+        comment_from_rest=_convert_non_inline_comment,
+    )
 
 
 def _fence_for(text: str, minimum: int = 3) -> str:

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -928,6 +928,8 @@ async def _fetch_pr_comments_rest_generic(
                     return None
 
                 for comment in page_comments:
+                    if len(all_comments) >= max_comments_v:
+                        break
                     all_comments.append(comment_from_rest(comment))
                 page_count += 1
 

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -38,7 +38,9 @@ from .github_api_constants import (
     GITHUB_USER_AGENT,
 )
 from .models import (
+    FetchPRNonInlineCommentsArgs,
     FetchPRReviewCommentsArgs,
+    NonInlineCommentModel,
     ResolveOpenPrUrlArgs,
     ReviewCommentModel,
 )
@@ -944,21 +946,200 @@ async def fetch_pr_comments(
         raise
 
 
+async def fetch_pr_non_inline_comments_rest(
+    owner: str,
+    repo: str,
+    pull_number: int,
+    *,
+    host: str = "github.com",
+    per_page: int | None = None,
+    max_pages: int | None = None,
+    max_comments: int | None = None,
+    max_retries: int | None = None,
+) -> list[CommentResult] | None:
+    """
+    Fetch non-inline pull request comments from the GitHub Issues API.
+
+    These are conversation-level comments on the PR itself (not code-line
+    review comments).
+    """
+    logger.debug(
+        "Fetching non-inline PR comments via REST",
+        extra={"owner": owner, "repo": repo, "pull_number": pull_number},
+    )
+    token = os.getenv("GITHUB_TOKEN")
+    headers: dict[str, str] = {
+        "Accept": GITHUB_ACCEPT_HEADER,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "User-Agent": GITHUB_USER_AGENT,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    safe_owner = quote(owner, safe="")
+    safe_repo = quote(repo, safe="")
+
+    per_page_v = _int_conf("HTTP_PER_PAGE", 100, 1, 100, per_page)
+    max_pages_v = _int_conf("PR_FETCH_MAX_PAGES", 50, 1, 200, max_pages)
+    max_comments_v = _int_conf("PR_FETCH_MAX_COMMENTS", 2000, 100, 100000, max_comments)
+    max_retries_v = _int_conf("HTTP_MAX_RETRIES", 3, 0, 10, max_retries)
+
+    api_base = api_base_for_host(host)
+    base_url = (
+        f"{api_base}/repos/"
+        f"{safe_owner}/{safe_repo}/issues/{pull_number}/comments?per_page={per_page_v}"
+    )
+    all_comments: list[CommentResult] = []
+    url: str | None = base_url
+    page_count = 0
+
+    total_timeout = _float_conf("HTTP_TIMEOUT", 30.0, TIMEOUT_MIN, TIMEOUT_MAX)
+    connect_timeout = _float_conf(
+        "HTTP_CONNECT_TIMEOUT", 10.0, CONNECT_TIMEOUT_MIN, CONNECT_TIMEOUT_MAX
+    )
+
+    try:
+        timeout = httpx.Timeout(timeout=total_timeout, connect=connect_timeout)
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            used_token_fallback = False
+            had_server_error = False
+            rate_limit_handler = RateLimitHandler("fetch_pr_non_inline_comments")
+            while url:
+                logger.debug(
+                    "Fetching REST API page for non-inline comments",
+                    extra={"page_number": page_count + 1, "url": url},
+                )
+
+                async def handle_rest_status(
+                    resp: httpx.Response, _attempt: int
+                ) -> str | None:
+                    nonlocal used_token_fallback, had_server_error
+
+                    if 500 <= resp.status_code < 600:
+                        had_server_error = True
+
+                    if (
+                        resp.status_code == 401
+                        and token
+                        and not used_token_fallback
+                        and headers.get("Authorization", "").startswith("Bearer ")
+                    ):
+                        logger.warning(
+                            "401 Unauthorized with Bearer token; "
+                            "retrying with legacy token scheme",
+                            extra={
+                                "status_code": 401,
+                                "auth_fallback": "bearer_to_token",
+                            },
+                        )
+                        headers["Authorization"] = f"token {token}"
+                        used_token_fallback = True
+                        return "retry"
+
+                    return await rate_limit_handler.handle_rate_limit(resp)
+
+                current_page_url = url
+
+                async def make_rest_request(
+                    page_url: str = current_page_url,
+                ) -> httpx.Response:
+                    return await client.get(page_url, headers=headers)
+
+                try:
+                    response = await _retry_http_request(
+                        make_rest_request,
+                        max_retries_v,
+                        status_handler=handle_rest_status,
+                    )
+                except SecondaryRateLimitError:
+                    return None
+                except httpx.HTTPStatusError as e:
+                    if 500 <= e.response.status_code < 600:
+                        return None
+                    raise
+
+                if had_server_error:
+                    return None
+
+                page_comments = response.json()
+                if not isinstance(page_comments, list) or not all(
+                    isinstance(c, dict) for c in page_comments
+                ):
+                    return None
+
+                for comment in page_comments:
+                    non_inline_comment_model = NonInlineCommentModel.from_rest(comment)
+                    all_comments.append(
+                        non_inline_comment_model.model_dump(exclude_none=True)
+                    )
+                page_count += 1
+
+                if page_count >= max_pages_v or len(all_comments) >= max_comments_v:
+                    print(
+                        "Reached safety limits for pagination; stopping early",
+                        file=sys.stderr,
+                    )
+                    break
+
+                link_header = response.headers.get("Link")
+                next_url: str | None = None
+                if link_header:
+                    match = re.search(r"<([^>]+)>;\s*rel=\"next\"", link_header)
+                    next_url = match.group(1) if match else None
+                logger.debug("REST next page", extra={"next_url": next_url})
+                if next_url:
+                    url = next_url
+                else:
+                    break
+
+        logger.info(
+            "Successfully fetched non-inline comments via REST",
+            extra={"total_comments": len(all_comments), "page_count": page_count},
+        )
+        return all_comments
+
+    except httpx.TimeoutException as e:
+        logger.error(
+            "Timeout fetching non-inline PR comments via REST",
+            extra={
+                "error": str(e),
+                "owner": owner,
+                "repo": repo,
+                "pull_number": pull_number,
+            },
+        )
+        traceback.print_exc(file=sys.stderr)
+        return None
+    except httpx.RequestError as e:
+        logger.error(
+            "Error fetching non-inline PR comments via REST",
+            extra={
+                "error": str(e),
+                "owner": owner,
+                "repo": repo,
+                "pull_number": pull_number,
+            },
+        )
+        traceback.print_exc(file=sys.stderr)
+        raise
+
+
+def _fence_for(text: str, minimum: int = 3) -> str:
+    """Choose a backtick fence longer than any backtick run in the text."""
+    longest_run = 0
+    current = 0
+    for ch in text or "":
+        if ch == "`":
+            current += 1
+            if current > longest_run:
+                longest_run = current
+        else:
+            current = 0
+    return "`" * max(minimum, longest_run + 1)
+
+
 def generate_markdown(comments: Sequence[CommentResult]) -> str:
     """Generates a markdown string from a list of review comments."""
-
-    def fence_for(text: str, minimum: int = 3) -> str:
-        # Choose a backtick fence longer than any run of backticks in the text
-        longest_run = 0
-        current = 0
-        for ch in text or "":
-            if ch == "`":
-                current += 1
-                if current > longest_run:
-                    longest_run = current
-            else:
-                current = 0
-        return "`" * max(minimum, longest_run + 1)
 
     markdown = "# Pull Request Review Comments\n\n"
     if not comments:
@@ -1009,18 +1190,58 @@ def generate_markdown(comments: Sequence[CommentResult]) -> str:
 
         # Escape comment body to prevent XSS - this is the main attack vector
         body = escape_html_safe(comment.get("body", ""))
-        body_fence = fence_for(body)
+        body_fence = _fence_for(body)
         markdown += f"**Comment:**\n{body_fence}\n{body}\n{body_fence}\n\n"
 
         if "diff_hunk" in comment:
             # Escape diff content to prevent injection through malicious diffs
             diff_text = escape_html_safe(comment["diff_hunk"])
-            diff_fence = fence_for(diff_text)
+            diff_fence = _fence_for(diff_text)
             # Language hint remains after the opening fence
             markdown += (
                 f"**Code Snippet:**\n{diff_fence}diff\n{diff_text}\n{diff_fence}\n\n"
             )
         markdown += "---\n\n"
+    return markdown
+
+
+def generate_non_inline_markdown(comments: Sequence[CommentResult]) -> str:
+    """Generate markdown for non-inline pull request comments."""
+    markdown = "# Pull Request Non-Inline Comments\n\n"
+    if not comments:
+        return markdown + "No comments found.\n"
+
+    for comment in comments:
+        if "error" in comment:
+            continue
+
+        user_data = comment.get("user")
+        login = user_data.get("login", "N/A") if isinstance(user_data, dict) else "N/A"
+        username = escape_html_safe(login)
+        markdown += f"## Comment by {username}\n\n"
+
+        created_at = comment.get("created_at")
+        if created_at:
+            markdown += f"**Created:** {escape_html_safe(created_at)}\n"
+
+        updated_at = comment.get("updated_at")
+        if updated_at and updated_at != created_at:
+            markdown += f"**Updated:** {escape_html_safe(updated_at)}\n"
+
+        comment_url = comment.get("html_url") or comment.get("url")
+        if comment_url:
+            markdown += f"**URL:** {escape_html_safe(comment_url)}\n"
+
+        association = comment.get("author_association")
+        if association:
+            markdown += f"**Author Association:** {escape_html_safe(association)}\n"
+
+        markdown += "\n"
+        body = escape_html_safe(comment.get("body", ""))
+        body_fence = _fence_for(body)
+        markdown += f"**Comment:**\n{body_fence}\n{body}\n{body_fence}\n\n"
+        markdown += "---\n\n"
+
     return markdown
 
 
@@ -1057,6 +1278,86 @@ class PRReviewServer:
                     "formatted Markdown by default (optimized for LLM consumption), "
                     "or JSON for programmatic use. Automatically detects PR from "
                     "current git branch if URL omitted."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "pr_url": {
+                            "type": "string",
+                            "description": (
+                                "The full URL of the GitHub pull request. If omitted, "
+                                "the server will try to resolve the PR for the current "
+                                "git repo and branch."
+                            ),
+                        },
+                        "output": {
+                            "type": "string",
+                            "enum": ["markdown", "json", "both"],
+                            "description": (
+                                "Output format. Default 'markdown'. Use 'json' for "
+                                "raw data; 'both' returns json then markdown."
+                            ),
+                        },
+                        "select_strategy": {
+                            "type": "string",
+                            "enum": ["branch", "latest", "first", "error"],
+                            "description": (
+                                "Strategy when auto-resolving a PR (default 'branch')."
+                            ),
+                        },
+                        "owner": {
+                            "type": "string",
+                            "description": "Override repo owner for PR resolution",
+                        },
+                        "repo": {
+                            "type": "string",
+                            "description": "Override repo name for PR resolution",
+                        },
+                        "branch": {
+                            "type": "string",
+                            "description": "Override branch name for PR resolution",
+                        },
+                        "per_page": {
+                            "type": "integer",
+                            "description": "GitHub API page size (1-100)",
+                            "minimum": 1,
+                            "maximum": 100,
+                        },
+                        "max_pages": {
+                            "type": "integer",
+                            "description": (
+                                "Max number of pages to fetch (server-capped)"
+                            ),
+                            "minimum": 1,
+                            "maximum": 200,
+                        },
+                        "max_comments": {
+                            "type": "integer",
+                            "description": (
+                                "Max total comments to collect (server-capped)"
+                            ),
+                            "minimum": 100,
+                            "maximum": 100000,
+                        },
+                        "max_retries": {
+                            "type": "integer",
+                            "description": (
+                                "Max retries for transient errors (server-capped)"
+                            ),
+                            "minimum": 0,
+                            "maximum": 10,
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="fetch_pr_non_inline_comments",
+                description=(
+                    "Fetches non-inline conversation comments from a GitHub PR "
+                    "(issue comments on the pull request timeline). Returns "
+                    "formatted Markdown by default, or JSON for programmatic use. "
+                    "Automatically detects PR from current git branch if URL "
+                    "omitted."
                 ),
                 inputSchema={
                     "type": "object",
@@ -1182,12 +1483,13 @@ class PRReviewServer:
 
         Parameters:
             name (str): The tool identifier to invoke (e.g.,
-                "fetch_pr_review_comments", "resolve_open_pr_url").
+                "fetch_pr_review_comments", "fetch_pr_non_inline_comments",
+                "resolve_open_pr_url").
             arguments (dict[str, Any]): Tool-specific arguments; expected keys
                 depend on `name` (for example, "pr_url", "per_page",
                 "max_pages", "max_comments", "max_retries",
                 "select_strategy", "owner", "repo", "branch", and "output" for
-                "fetch_pr_review_comments").
+                fetch tools).
 
         Returns:
             Sequence[TextContent]: One or more text outputs produced by the
@@ -1211,12 +1513,14 @@ class PRReviewServer:
                 traceback.print_exc(file=sys.stderr)
                 raise RuntimeError(error_msg) from exc
 
-        if name == "fetch_pr_review_comments":
-            # Validate arguments using Pydantic model
+        def _validate_fetch_tool_args(
+            args: dict[str, Any],
+            args_model: type[FetchPRReviewCommentsArgs]
+            | type[FetchPRNonInlineCommentsArgs],
+        ) -> dict[str, Any]:
             try:
-                validated_args = FetchPRReviewCommentsArgs.model_validate(arguments)
+                validated_args = args_model.model_validate(args)
             except ValidationError as e:
-                # Transform Pydantic validation errors to ValueError
                 errors = e.errors()
                 if errors:
                     first_error = errors[0]
@@ -1224,14 +1528,11 @@ class PRReviewServer:
                     msg = first_error["msg"]
                     error_type = first_error["type"]
 
-                    # Handle different error types
                     if error_type == "value_error":
-                        # This is from our custom field_validator rejecting bool/float
                         raise ValueError(
                             f"Invalid type for {field}: expected integer"
                         ) from None
                     if error_type == "literal_error":
-                        # Distinguish between output and select_strategy fields
                         if field == "output":
                             raise ValueError(
                                 f"Invalid {field}: "
@@ -1251,12 +1552,7 @@ class PRReviewServer:
                         "greater_than_equal" in error_type
                         or "less_than_equal" in error_type
                     ):
-                        # Extract actual range from field constraints
-                        field_info = FetchPRReviewCommentsArgs.model_fields.get(
-                            str(field)
-                        )
-
-                        # Try to get constraints from field_info metadata
+                        field_info = args_model.model_fields.get(str(field))
                         min_val = None
                         max_val = None
                         if field_info and field_info.metadata:
@@ -1266,7 +1562,6 @@ class PRReviewServer:
                                 if hasattr(constraint, "le"):
                                     max_val = constraint.le
 
-                        # Fall back to error context from Pydantic
                         if min_val is None or max_val is None:
                             error_ctx = first_error.get("ctx") or {}
                             if min_val is None:
@@ -1274,7 +1569,6 @@ class PRReviewServer:
                             if max_val is None:
                                 max_val = error_ctx.get("le")
 
-                        # Build error message with available constraints
                         if min_val is not None and max_val is not None:
                             raise ValueError(
                                 f"Invalid value for {field}: "
@@ -1288,19 +1582,24 @@ class PRReviewServer:
                             raise ValueError(
                                 f"Invalid value for {field}: must be <= {max_val}"
                             ) from None
-
-                        # Final fallback
                         raise ValueError(
                             f"Invalid value for {field}: out of range"
                         ) from None
                     raise ValueError(f"Invalid value for {field}: {msg}") from None
                 raise ValueError("Invalid arguments") from None
 
-            # Extract validated arguments
-            args_dict = validated_args.model_dump(exclude_none=True)
+            return validated_args.model_dump(exclude_none=True)
 
+        async def _run_fetch_tool(
+            *,
+            args_model: type[FetchPRReviewCommentsArgs]
+            | type[FetchPRNonInlineCommentsArgs],
+            fetcher: Callable[..., Awaitable[list[CommentResult]]],
+            markdown_renderer: Callable[[Sequence[CommentResult]], str],
+        ) -> list[TextContent]:
+            args_dict = _validate_fetch_tool_args(arguments, args_model)
             comments = await _run_with_handling(
-                lambda: self.fetch_pr_review_comments(
+                lambda: fetcher(
                     pr_url=args_dict.get("pr_url"),
                     per_page=args_dict.get("per_page"),
                     max_pages=args_dict.get("max_pages"),
@@ -1312,21 +1611,33 @@ class PRReviewServer:
                     branch=args_dict.get("branch"),
                 )
             )
-
             output = args_dict.get("output", "markdown")
 
-            # Build responses according to requested format (default markdown)
             results: list[TextContent] = []
             if output in ("json", "both"):
                 results.append(TextContent(type="text", text=json.dumps(comments)))
             if output in ("markdown", "both"):
                 try:
-                    md = generate_markdown(comments)
+                    md = markdown_renderer(comments)
                 except (AttributeError, KeyError, TypeError, IndexError) as exc:
                     traceback.print_exc(file=sys.stderr)
                     md = f"# Error\n\nFailed to generate markdown from comments: {exc}"
                 results.append(TextContent(type="text", text=md))
             return results
+
+        if name == "fetch_pr_review_comments":
+            return await _run_fetch_tool(
+                args_model=FetchPRReviewCommentsArgs,
+                fetcher=self.fetch_pr_review_comments,
+                markdown_renderer=generate_markdown,
+            )
+
+        if name == "fetch_pr_non_inline_comments":
+            return await _run_fetch_tool(
+                args_model=FetchPRNonInlineCommentsArgs,
+                fetcher=self.fetch_pr_non_inline_comments,
+                markdown_renderer=generate_non_inline_markdown,
+            )
 
         if name == "resolve_open_pr_url":
             # Validate arguments using Pydantic model
@@ -1459,6 +1770,56 @@ class PRReviewServer:
             return comments if comments is not None else []
         except ValueError as e:
             error_msg = f"Error in fetch_pr_review_comments: {str(e)}"
+            print(error_msg, file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+            return [{"error": error_msg}]
+
+    async def fetch_pr_non_inline_comments(
+        self,
+        pr_url: str | None,
+        *,
+        per_page: int | None = None,
+        max_pages: int | None = None,
+        max_comments: int | None = None,
+        max_retries: int | None = None,
+        select_strategy: str | None = None,
+        owner: str | None = None,
+        repo: str | None = None,
+        branch: str | None = None,
+    ) -> list[CommentResult]:
+        """Fetch non-inline conversation comments for a pull request."""
+        print(
+            f"Tool 'fetch_pr_non_inline_comments' called with pr_url: {pr_url}",
+            file=sys.stderr,
+        )
+        try:
+            if not pr_url:
+                tool_resp = await self.handle_call_tool(
+                    "resolve_open_pr_url",
+                    {
+                        "select_strategy": select_strategy or "branch",
+                        "owner": owner,
+                        "repo": repo,
+                        "branch": branch,
+                    },
+                )
+                pr_url = tool_resp[0].text
+
+            host, owner, repo, pull_number_str = get_pr_info(pr_url)
+            pull_number = int(pull_number_str)
+            comments = await fetch_pr_non_inline_comments_rest(
+                owner,
+                repo,
+                pull_number,
+                host=host,
+                per_page=per_page,
+                max_pages=max_pages,
+                max_comments=max_comments,
+                max_retries=max_retries,
+            )
+            return comments if comments is not None else []
+        except ValueError as e:
+            error_msg = f"Error in fetch_pr_non_inline_comments: {str(e)}"
             print(error_msg, file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
             return [{"error": error_msg}]

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -12,6 +12,7 @@ from mcp_github_pr_review.server import (
     PRReviewServer,
     fetch_pr_comments,
     generate_markdown,
+    generate_non_inline_markdown,
 )
 
 
@@ -39,12 +40,19 @@ def test_generate_markdown_skips_error_entries() -> None:
     assert "Review Comment by dev" in result
 
 
+def test_generate_non_inline_markdown_no_comments() -> None:
+    """Should handle empty non-inline comment list."""
+    result = generate_non_inline_markdown([])
+    assert result == "# Pull Request Non-Inline Comments\n\nNo comments found.\n"
+
+
 @pytest.mark.asyncio
 async def test_handle_list_tools(mcp_server: PRReviewServer) -> None:
     tools = await mcp_server.handle_list_tools()
     names = {tool.name for tool in tools}
     assert {
         "fetch_pr_review_comments",
+        "fetch_pr_non_inline_comments",
         "resolve_open_pr_url",
     } <= names
 
@@ -95,6 +103,17 @@ async def test_handle_call_tool_invalid_output(mcp_server: PRReviewServer) -> No
     with pytest.raises(ValueError, match="Invalid output"):
         await mcp_server.handle_call_tool(
             "fetch_pr_review_comments",
+            {"pr_url": "https://github.com/o/r/pull/1", "output": "text"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_non_inline_invalid_output(
+    mcp_server: PRReviewServer,
+) -> None:
+    with pytest.raises(ValueError, match="Invalid output"):
+        await mcp_server.handle_call_tool(
+            "fetch_pr_non_inline_comments",
             {"pr_url": "https://github.com/o/r/pull/1", "output": "text"},
         )
 
@@ -243,6 +262,35 @@ async def test_handle_call_tool_fetch_output_both(
 
 
 @pytest.mark.asyncio
+async def test_handle_call_tool_fetch_non_inline_output_both(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    async def mock_fetch(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "user": {"login": "alice"},
+                "body": "General note",
+                "created_at": "2025-01-01T00:00:00Z",
+                "html_url": "https://github.com/a/b/pull/1#issuecomment-1",
+            }
+        ]
+
+    monkeypatch.setattr(mcp_server, "fetch_pr_non_inline_comments", mock_fetch)
+
+    result = await mcp_server.handle_call_tool(
+        "fetch_pr_non_inline_comments",
+        {"pr_url": "https://github.com/a/b/pull/1", "output": "both"},
+    )
+
+    assert len(result) == 2
+    json_text = result[0].text
+    markdown_text = result[1].text
+    assert json.loads(json_text)[0]["body"] == "General note"
+    assert "Comment by alice" in markdown_text
+
+
+@pytest.mark.asyncio
 async def test_fetch_pr_review_comments_invalid_url(
     mcp_server: PRReviewServer,
 ) -> None:
@@ -286,6 +334,60 @@ async def test_handle_call_tool_passes_numeric_overrides(
 
     result = await mcp_server.handle_call_tool(
         "fetch_pr_review_comments",
+        {
+            "pr_url": "https://github.com/o/r/pull/1",
+            "per_page": 5,
+            "max_pages": 10,
+            "max_comments": 200,
+            "max_retries": 2,
+            "output": "json",
+        },
+    )
+
+    assert captured == {
+        "pr_url": "https://github.com/o/r/pull/1",
+        "per_page": 5,
+        "max_pages": 10,
+        "max_comments": 200,
+        "max_retries": 2,
+    }
+    assert result[0].text == "[]"
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_non_inline_passes_numeric_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def mock_fetch(
+        pr_url: str,
+        *,
+        per_page: int | None,
+        max_pages: int | None,
+        max_comments: int | None,
+        max_retries: int | None,
+        select_strategy: str | None,
+        owner: str | None,
+        repo: str | None,
+        branch: str | None,
+    ) -> list[dict[str, Any]]:
+        captured.update(
+            {
+                "pr_url": pr_url,
+                "per_page": per_page,
+                "max_pages": max_pages,
+                "max_comments": max_comments,
+                "max_retries": max_retries,
+            }
+        )
+        return []
+
+    monkeypatch.setattr(mcp_server, "fetch_pr_non_inline_comments", mock_fetch)
+
+    result = await mcp_server.handle_call_tool(
+        "fetch_pr_non_inline_comments",
         {
             "pr_url": "https://github.com/o/r/pull/1",
             "per_page": 5,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,9 +5,11 @@ from pydantic import ValidationError
 
 from mcp_github_pr_review.models import (
     ErrorMessageModel,
+    FetchPRNonInlineCommentsArgs,
     FetchPRReviewCommentsArgs,
     GitContextModel,
     GitHubUserModel,
+    NonInlineCommentModel,
     ResolveOpenPrUrlArgs,
     ReviewCommentModel,
 )
@@ -460,6 +462,33 @@ class TestReviewCommentModel:
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
 
+class TestNonInlineCommentModel:
+    """Tests for NonInlineCommentModel."""
+
+    def test_from_rest_with_complete_data(self) -> None:
+        rest_data = {
+            "id": 123,
+            "user": {"login": "octocat"},
+            "body": "General discussion comment",
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-02T00:00:00Z",
+            "url": "https://api.github.com/repos/o/r/issues/comments/123",
+            "html_url": "https://github.com/o/r/pull/1#issuecomment-123",
+            "author_association": "CONTRIBUTOR",
+        }
+        comment = NonInlineCommentModel.from_rest(rest_data)
+        assert comment.id == 123
+        assert comment.user.login == "octocat"
+        assert comment.body == "General discussion comment"
+        assert comment.created_at == "2025-01-01T00:00:00Z"
+        assert comment.updated_at == "2025-01-02T00:00:00Z"
+        assert comment.author_association == "CONTRIBUTOR"
+
+    def test_from_rest_defaults_missing_user_to_unknown(self) -> None:
+        comment = NonInlineCommentModel.from_rest({"body": "No user"})
+        assert comment.user.login == "unknown"
+
+
 class TestFetchPRReviewCommentsArgs:
     """Tests for FetchPRReviewCommentsArgs."""
 
@@ -620,6 +649,30 @@ class TestFetchPRReviewCommentsArgs:
         with pytest.raises(ValidationError) as exc_info:
             FetchPRReviewCommentsArgs(extra_field="value")  # type: ignore
         assert "Extra inputs are not permitted" in str(exc_info.value)
+
+
+class TestFetchPRNonInlineCommentsArgs:
+    """Tests for FetchPRNonInlineCommentsArgs."""
+
+    def test_creates_with_defaults(self) -> None:
+        args = FetchPRNonInlineCommentsArgs()
+        assert args.pr_url is None
+        assert args.output == "markdown"
+        assert args.select_strategy == "branch"
+
+    def test_validates_output_enum(self) -> None:
+        args = FetchPRNonInlineCommentsArgs(output="json")
+        assert args.output == "json"
+
+        with pytest.raises(ValidationError) as exc_info:
+            FetchPRNonInlineCommentsArgs(output="invalid")  # type: ignore
+        error_str = str(exc_info.value)
+        assert "markdown" in error_str and "json" in error_str and "both" in error_str
+
+    def test_rejects_boolean_numeric_fields(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            FetchPRNonInlineCommentsArgs(per_page=True)  # type: ignore
+        assert "Invalid type: expected integer" in str(exc_info.value)
 
 
 class TestResolveOpenPrUrlArgs:

--- a/tests/test_pagination_limits.py
+++ b/tests/test_pagination_limits.py
@@ -59,8 +59,8 @@ async def test_comment_count_limit_stops_early(mock_http_client) -> None:
 
     We enqueue pages with 60 comments each and set max_comments=100 (the
     implementation clamps small values up to a minimum of 100). The function
-    processes page 1 (60 items) and page 2 (60 items), then stops because
-    120 >= 100.
+    processes page 1 fully (60 items), then ingests only the first 40 comments
+    of page 2 before hitting the cap and stopping.
     We assert no third page is fetched.
     """
     headers_with_next = {"Link": '<https://api.github.com/next>; rel="next"'}
@@ -77,8 +77,8 @@ async def test_comment_count_limit_stops_early(mock_http_client) -> None:
     )
 
     assert isinstance(comments, list)
-    # Page 1: 60, Page 2: 60 -> total 120 (>= 100), then stop
-    assert len(comments) == 120, "Stops after exceeding max_comments"
-    assert len(mock_http_client.get_calls) == 2, (
-        "Should not fetch a third page once limit reached"
-    )
+    # Page 1: 60, Page 2: only 40 ingested -> total 100, then stop
+    assert len(comments) == 100, "Should cap returned comments at max_comments"
+    assert (
+        len(mock_http_client.get_calls) == 2
+    ), "Should not fetch a third page once limit reached"


### PR DESCRIPTION
This PR adds a new MCP tool, `fetch_pr_non_inline_comments`, to fetch pull request conversation comments from the Issues API (`/issues/{pull_number}/comments`) alongside existing inline review comment support.
It introduces validated Pydantic models and shared fetch-tool argument handling, plus markdown/JSON output paths and updated tool registration and docs.
The implementation includes comprehensive tests for model validation, tool listing/dispatch, output formatting, and argument passthrough, and the full quality pipeline passed (`uv run ruff format .`, `uv run ruff check --fix .`, `uv run mypy .`, `make compile-check`, `uv run pytest`).
This closes the gap where only inline review comments were available to MCP clients.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public tool to fetch non-inline pull-request comments with pagination, retry controls, and selectable Markdown/JSON outputs.

* **Documentation**
  * Added full parameter specs, return semantics, and Markdown/JSON examples for the new tool; reordered tool listing.

* **Models**
  * Introduced public data types and argument schemas for non-inline comments and fetch options.

* **Tests**
  * Added tests covering non-inline fetching, output validation, numeric overrides, and combined outputs.

* **Bug Fixes**
  * Tightened pagination to respect max_comments precisely (partial final-page consumption).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->