### PR TITLE
feat: implement MCP architecture review spec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"  
+      day: "monday"
       time: "03:30"
     target-branch: "master"
     labels:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run Ruff formatter check
         run: uv run ruff format --check .
-      
+
       - name: Type check with mypy and report coverage
         run: |
           uv run mypy --strict --linecount-report .mypy-coverage .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           # Don't run integration tests in CI unless token is provided
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -182,9 +182,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,19 @@ uv run ruff format . && uv run ruff check --fix . && uv run mypy . && make compi
 uv run ruff format --check . && uv run ruff check . && uv run mypy . && make compile-check && uv run pytest
 ```
 
+## Pre-commit Hook Installation Notes
+
+- Standard hook install commands:
+  - `uv run --extra dev pre-commit install`
+  - `uv run --extra dev pre-commit install --hook-type commit-msg`
+- Smoke check:
+  - `uv run --extra dev pre-commit run --all-files`
+- If `pre-commit install` is blocked by a global `core.hooksPath` (for example `/usr/local/dd/global_hooks`), install hooks directly into the repo's `.git/hooks` via pre-commit's install API.
+- In this repository, that produced:
+  - `<repo>/.git/hooks/pre-commit`
+  - `<repo>/.git/hooks/commit-msg`
+- Ensure both hook scripts exist and are executable. Treat these as example paths and adapt for your local environment. The global hook chain should call into these repo-level hooks.
+
 ## HTTP Transport
 
 The server supports both stdio (default) and HTTP transport:

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,3 @@ coverage:
 
 sync:
 	uv sync --dev
-

--- a/README.md
+++ b/README.md
@@ -111,10 +111,18 @@ This project uses [pre-commit](https://pre-commit.com/) to run formatting, linti
 ```bash
 # Install the git hook scripts
 uv run --extra dev pre-commit install
+uv run --extra dev pre-commit install --hook-type commit-msg
 
 # Run all checks on every file
 uv run --extra dev pre-commit run --all-files
 ```
+
+If `pre-commit install` is blocked because you use a global `core.hooksPath` (for example, `/usr/local/dd/global_hooks`), install hooks directly into the repo hooks directory via pre-commit's install API instead. In this repo, that created:
+
+- `.git/hooks/pre-commit`
+- `.git/hooks/commit-msg`
+
+These are example paths relative to the repository root and should be adapted to your local environment. Both scripts should be executable. The global hook chain is expected to invoke these repo-level hooks.
 
 ## Running the MCP Server
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ This approach follows the principle of least privilege and separates concerns ap
 
 - **Token-based authentication**: Supports both fine-grained Personal Access Tokens (PATs) and classic PATs
 - **Automatic fallback handling**: If Bearer token fails with 401, automatically retries with token scheme for classic PATs
-- **Minimal required scopes**: 
+- **Minimal required scopes**:
   - Public repos: `public_repo` scope only
   - Private repos: `repo` scope only
   - Fine-grained PATs: Pull requests → Read access only
@@ -56,7 +56,7 @@ This approach follows the principle of least privilege and separates concerns ap
 
 ### Memory & Resource Protection
 
-- **Pagination limits**: 
+- **Pagination limits**:
   - Maximum 200 pages (configurable, default 50)
   - Maximum 100,000 comments (configurable, default 2,000)
 - **Per-page limits**: 1-100 comments per page (GitHub API limit)

--- a/TEST_COVERAGE_SUMMARY.md
+++ b/TEST_COVERAGE_SUMMARY.md
@@ -126,18 +126,18 @@ Added **9 comprehensive test functions** to `tests/test_graphql_error_handling.p
 - File size: 540 lines → 1157 lines
 
 ### Coverage Areas
-✅ **Happy Path**: Normal limit enforcement  
-✅ **Edge Cases**: Boundary conditions, exact limits  
-✅ **Loop Breaking**: Both outer (threads) and inner (comments) loops  
-✅ **Pagination**: Multi-page scenarios with limits  
-✅ **Diagnostic Output**: stderr message verification  
-✅ **Empty Data**: Empty threads handling  
-✅ **Flag Logic**: limit_reached flag behavior  
+✅ **Happy Path**: Normal limit enforcement
+✅ **Edge Cases**: Boundary conditions, exact limits
+✅ **Loop Breaking**: Both outer (threads) and inner (comments) loops
+✅ **Pagination**: Multi-page scenarios with limits
+✅ **Diagnostic Output**: stderr message verification
+✅ **Empty Data**: Empty threads handling
+✅ **Flag Logic**: limit_reached flag behavior
 
 ### Testing Framework & Patterns Used
 
-**Framework**: pytest with pytest-asyncio  
-**Mocking**: unittest.mock (AsyncMock, MagicMock, patch)  
+**Framework**: pytest with pytest-asyncio
+**Mocking**: unittest.mock (AsyncMock, MagicMock, patch)
 **Fixtures Used**:
 - `monkeypatch`: Environment variable configuration
 - `github_token`: Mock GitHub authentication

--- a/UV_COMMANDS.md
+++ b/UV_COMMANDS.md
@@ -8,7 +8,7 @@ uv sync --dev
 # Run linting
 uv run ruff check .
 
-# Run linting with auto-fix  
+# Run linting with auto-fix
 uv run ruff check --fix .
 
 # Format code
@@ -29,4 +29,3 @@ uv run mcp-github-pr-review
 # Format, lint, and test in one command
 uv run ruff format . && uv run ruff check --fix . && uv run pytest
 ```
-

--- a/specs/MCP-ARCH-REVIEW.md
+++ b/specs/MCP-ARCH-REVIEW.md
@@ -1,0 +1,256 @@
+# MCP Architecture Review Verification Plan
+
+## Purpose
+
+Validate that the MCP server architecture changes improve reliability, discoverability, output consistency, safety signaling, and agent usability.
+
+This plan is designed to verify both:
+- **Current-state gaps** (to confirm known issues are reproducible)
+- **Post-refactor behavior** (to confirm fixes are complete and stable)
+
+## Scope
+
+In scope:
+- MCP tool definitions and schemas
+- Tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- Input validation behavior
+- Output shape and schema conformance
+- Pagination/filtering guarantees
+- Error normalization and actionability
+- Basic runtime safety and deterministic behavior
+
+Out of scope:
+- GitHub production load/performance benchmarking
+- End-to-end third-party editor UX behavior
+- Non-MCP CLI ergonomics unrelated to tool contracts
+
+## Preconditions
+
+1. Local checkout is clean.
+2. Dependencies are installed:
+   ```bash
+   uv sync --dev
+   ```
+3. A valid `GITHUB_TOKEN` is set:
+   ```bash
+   export GITHUB_TOKEN=...
+   ```
+4. Optional GHES testing values are available if enterprise scenarios are validated:
+   - `GH_HOST`
+   - `GITHUB_API_URL`
+   - `GITHUB_GRAPHQL_URL`
+
+## Verification Environments
+
+- **Primary**: `stdio` transport via MCP Inspector
+- **Secondary**: HTTP transport smoke test (if enabled)
+
+## Success Criteria (Gate)
+
+All of the following must pass:
+
+1. Tool catalog is discoverable and internally consistent.
+2. Every tool has strict input schema and explicit safety annotations.
+3. List-like tool responses are bounded and paginated (no unbounded defaults).
+4. Structured output exists and matches declared output schema.
+5. Error responses are normalized, actionable, and do not leak secrets.
+6. Validation failures are deterministic and field-specific.
+7. Existing tests pass and new contract tests are added for changed behavior.
+
+## Phase 1: Tool Surface Verification
+
+### 1.1 Inspect Tool Metadata
+
+Use MCP Inspector to run `tools/list` and validate:
+
+- Names follow `service_action_resource` (or compatibility alias is clearly marked deprecated).
+- Descriptions are one sentence in form: `Does X and returns Y`.
+- `inputSchema` exists and includes constraints (`type`, `enum`, `minimum`, `maximum`, defaults where expected).
+- `outputSchema` exists for tools returning structured output.
+- `annotations` exist and are correct.
+
+Expected result:
+- Read-only tools are marked `readOnlyHint=true`, `destructiveHint=false`, `idempotentHint=true`.
+
+### 1.2 Schema Strictness Checks
+
+For each tool schema, confirm:
+
+- Unknown properties are rejected (`additionalProperties: false` or equivalent strict model behavior).
+- Free-form strings are avoided when explicit fields are expected.
+- Optional fields are explicit and correctly typed.
+
+## Phase 2: Functional Verification in MCP Inspector
+
+Run the following high-value calls in order. Capture request/response JSON for each.
+
+### 2.1 Core Resolution Tool
+
+1. `resolve_open_pr_url` (or renamed equivalent) with default args.
+2. Same call with explicit `owner`, `repo`, `branch`.
+3. Same call with `select_strategy=latest`.
+
+Expected:
+- Returns a single valid PR URL.
+- Failure paths provide normalized, actionable errors.
+
+### 2.2 Comment Listing / Fetch Tool (Primary)
+
+4. Basic call with only `pr_url`.
+5. Paginated call with explicit `limit` (or equivalent bounded field).
+6. Follow-up call using returned `cursor` / `nextPageToken`.
+7. Filtered call (e.g., `is_resolved`, `author`, `path_prefix`) if implemented.
+
+Expected:
+- Response includes consistent envelope:
+  - `items`
+  - `nextCursor`/`nextPageToken`
+  - `total` (when available)
+- No unbounded response by default.
+- Cursor advances deterministically.
+
+### 2.3 Validation and Error Behavior
+
+8. Invalid enum value (e.g., bad `output` or `select_strategy`).
+9. Out-of-range numeric value (`limit=0`, oversized page size).
+10. Unknown parameter injection (`{"unexpectedField":"x"}`).
+11. Missing auth token scenario (unset `GITHUB_TOKEN` and retry one read-only call).
+12. Rate-limit simulation path (via test harness/mocks if live triggering is impractical).
+
+Expected:
+- Errors are normalized with:
+  - what failed
+  - likely why
+  - exact next steps
+- No token leakage in any error body/log output returned to client.
+
+## Phase 3: Output Contract Verification
+
+### 3.1 Content + Structured Content
+
+Verify each tool response includes:
+
+- A brief human-readable text in `content`
+- Structured data in `structuredContent` when supported/declared
+
+Expected:
+- No schema drift between documented and actual structured payload keys.
+- If `outputSchema` is declared, returned payload validates.
+
+### 3.2 Determinism Checks
+
+Repeat the same request 2-3 times (stable PR, no new comments) and confirm:
+
+- Field names and top-level shape remain identical
+- Ordering is stable or ordering guarantees are documented
+
+## Phase 4: Safety and Architecture Conformance
+
+### 4.1 Safety Hint Audit
+
+Confirm all tools have explicit annotation values and that they match real behavior.
+
+### 4.2 Module Boundary Audit
+
+Confirm implementation structure aligns with:
+
+- `client/` for auth + request wrapper
+- `tools/` for handlers
+- `schemas/` for input/output models
+- `errors/` for normalized errors
+- `pagination/` helpers
+- `types/` shared typed structures
+
+Expected:
+- No duplicate HTTP request logic across modules.
+- Runtime config validated once at startup.
+
+## Phase 5: Automated Test Verification
+
+Run:
+
+```bash
+uv run ruff format .
+uv run ruff check --fix .
+uv run mypy .
+make compile-check
+uv run pytest
+```
+
+Required test coverage additions (or equivalent):
+
+- Tool annotation presence and correctness
+- `tools/list` schema strictness checks
+- Output schema validation tests
+- Cursor pagination continuation tests
+- Normalized error payload tests (auth, validation, rate-limit)
+- Unknown argument rejection tests
+
+## Evidence Collection
+
+Store artifacts in `.context/mcp-arch-review/`:
+
+- `tools-list.json`
+- `call-01-...json` through `call-12-...json`
+- `pytest.log`
+- `mypy.log`
+- `ruff.log`
+- `summary.md`
+
+## Report Template
+
+Use this summary template at completion:
+
+```md
+## MCP Architecture Review Verification Summary
+
+### Status
+- Result: PASS | FAIL | PARTIAL
+- Date:
+- Commit:
+
+### Tooling
+- [ ] Tool names and descriptions conform
+- [ ] Annotations complete and accurate
+
+### Schemas
+- [ ] Strict validation enforced
+- [ ] Output schemas present where required
+
+### Outputs
+- [ ] content + structuredContent consistency
+- [ ] Standardized list envelope (`items`, `nextCursor`, `total`)
+
+### Errors
+- [ ] Normalized and actionable
+- [ ] No secret leakage
+
+### Pagination
+- [ ] Bounded defaults
+- [ ] Cursor continuation works
+
+### Tests
+- [ ] Ruff, mypy, compile-check, pytest all pass
+
+### Notes / Follow-ups
+- ...
+```
+
+## Fail Conditions
+
+Any of the following is an automatic failure:
+
+- Tool returns unbounded list without explicit pagination limits.
+- Declared schema does not match runtime payload.
+- Missing/incorrect safety hints.
+- Errors are non-actionable or leak sensitive values.
+- Tool behavior contradicts documentation in a way that affects agent control flow.
+
+## Recommended Execution Order
+
+1. `tools/list` metadata and schema audit
+2. Positive-path functional calls
+3. Negative-path validation/error calls
+4. Determinism and pagination checks
+5. Lint/type/test gates
+6. Final summary artifact generation

--- a/specs/MCP-ARCH-REVIEW.md
+++ b/specs/MCP-ARCH-REVIEW.md
@@ -152,18 +152,25 @@ Confirm all tools have explicit annotation values and that they match real behav
 
 ### 4.2 Module Boundary Audit
 
-Confirm implementation structure aligns with:
+Confirm implementation structure aligns with the current flat package layout in
+`src/mcp_github_pr_review/`:
 
-- `client/` for auth + request wrapper
-- `tools/` for handlers
-- `schemas/` for input/output models
-- `errors/` for normalized errors
-- `pagination/` helpers
-- `types/` shared typed structures
+- `server.py` for MCP tool registration and orchestration
+- `models.py` for validated input/output schemas
+- `errors.py` for normalized tool error envelopes
+- `pagination.py` for cursor encode/decode helpers
+- `git_pr_resolver.py` for repository/PR detection and URL resolution
+
+If the codebase is later refactored into `client/`, `tools/`, `schemas/`,
+`errors/`, `pagination/`, and `types/`, use this verification plan to enforce
+behavioral parity with the current modules.
 
 Expected:
-- No duplicate HTTP request logic across modules.
-- Runtime config validated once at startup.
+- Runtime config validation happens once at startup/bootstrap in
+  `server.py` before tool execution paths fan out.
+- HTTP request/retry behavior is centralized (for example via
+  `_retry_http_request` + `RateLimitHandler`) with no duplicated ad-hoc
+  request wrappers in multiple modules.
 
 ## Phase 5: Automated Test Verification
 

--- a/specs/PYDANTIC_MODEL_INTEGRATION.md
+++ b/specs/PYDANTIC_MODEL_INTEGRATION.md
@@ -246,4 +246,3 @@
   - Exposing Pydantic models would create additional maintenance burden
   - MCP clients don't benefit from schema export currently
 - **Future Consideration**: Re-evaluate if MCP protocol adds schema negotiation capabilities
-

--- a/src/mcp_github_pr_review/errors.py
+++ b/src/mcp_github_pr_review/errors.py
@@ -1,0 +1,24 @@
+"""Normalized MCP tool error helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .models import ToolErrorDetailsModel
+
+
+@dataclass(frozen=True)
+class ToolExecutionError(Exception):
+    """Actionable error information for canonical MCP tool responses."""
+
+    code: str
+    message: str
+    next_steps: list[str] = field(default_factory=list)
+
+    def to_model(self) -> ToolErrorDetailsModel:
+        """Convert error details to the normalized response model."""
+        return ToolErrorDetailsModel(
+            code=self.code,  # type: ignore[arg-type]
+            message=self.message,
+            next_steps=self.next_steps,
+        )

--- a/src/mcp_github_pr_review/errors.py
+++ b/src/mcp_github_pr_review/errors.py
@@ -4,21 +4,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .models import ToolErrorDetailsModel
+from .models import ToolErrorCode, ToolErrorDetailsModel
 
 
 @dataclass(frozen=True)
 class ToolExecutionError(Exception):
     """Actionable error information for canonical MCP tool responses."""
 
-    code: str
+    code: ToolErrorCode
     message: str
     next_steps: list[str] = field(default_factory=list)
 
     def to_model(self) -> ToolErrorDetailsModel:
         """Convert error details to the normalized response model."""
         return ToolErrorDetailsModel(
-            code=self.code,  # type: ignore[arg-type]
+            code=self.code,
             message=self.message,
             next_steps=self.next_steps,
         )

--- a/src/mcp_github_pr_review/models.py
+++ b/src/mcp_github_pr_review/models.py
@@ -301,9 +301,18 @@ class PaginatedReviewCommentsResult(BaseModel):
     next_cursor: str | None = Field(
         default=None,
         alias="nextCursor",
-        serialization_alias="nextCursor",
     )
     total: int | None = Field(default=None, ge=0)
+
+
+ToolErrorCode = Literal[
+    "invalid_arguments",
+    "auth",
+    "not_found",
+    "rate_limited",
+    "upstream",
+    "internal_error",
+]
 
 
 class ToolErrorDetailsModel(BaseModel):
@@ -314,14 +323,7 @@ class ToolErrorDetailsModel(BaseModel):
         validate_assignment=True,
     )
 
-    code: Literal[
-        "invalid_arguments",
-        "auth",
-        "not_found",
-        "rate_limited",
-        "upstream",
-        "internal_error",
-    ]
+    code: ToolErrorCode
     message: str = Field(min_length=1)
     next_steps: list[str] = Field(default_factory=list)
 

--- a/src/mcp_github_pr_review/models.py
+++ b/src/mcp_github_pr_review/models.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, field_validator
 
 
 class GitHubUserModel(BaseModel):
@@ -243,3 +243,95 @@ class ResolveOpenPrUrlArgs(BaseModel):
     repo: str | None = None
     branch: str | None = None
     select_strategy: Literal["branch", "latest", "first", "error"] = "branch"
+
+
+class GithubListPrReviewCommentsArgs(BaseModel):
+    """Arguments for the github_list_pr_review_comments MCP tool."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    pr_url: str | None = None
+    owner: str | None = None
+    repo: str | None = None
+    branch: str | None = None
+    host: str | None = None
+    select_strategy: Literal["branch", "latest", "first", "error"] = "branch"
+    limit: StrictInt = Field(default=50, ge=1, le=100)
+    cursor: str | None = None
+    author: str | None = None
+    path_prefix: str | None = None
+    include_resolved: bool | None = None
+
+    @field_validator("author", "path_prefix", mode="before")
+    @classmethod
+    def strip_optional_text(cls, v: Any) -> Any:
+        """Normalize optional text filters and reject empty strings."""
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            return v
+        value = v.strip()
+        return value or None
+
+
+class GithubResolveOpenPrUrlResult(BaseModel):
+    """Structured result for github_resolve_open_pr_url."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    url: str = Field(min_length=1)
+
+
+class PaginatedReviewCommentsResult(BaseModel):
+    """Structured paginated list response for review comments."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+        populate_by_name=True,
+    )
+
+    items: list[ReviewCommentModel] = Field(default_factory=list)
+    next_cursor: str | None = Field(
+        default=None,
+        alias="nextCursor",
+        serialization_alias="nextCursor",
+    )
+    total: int | None = Field(default=None, ge=0)
+
+
+class ToolErrorDetailsModel(BaseModel):
+    """Normalized, actionable tool error details."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    code: Literal[
+        "invalid_arguments",
+        "auth",
+        "not_found",
+        "rate_limited",
+        "upstream",
+        "internal_error",
+    ]
+    message: str = Field(min_length=1)
+    next_steps: list[str] = Field(default_factory=list)
+
+
+class ToolErrorEnvelopeModel(BaseModel):
+    """Error envelope shape used by canonical MCP tools."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    error: ToolErrorDetailsModel

--- a/src/mcp_github_pr_review/pagination.py
+++ b/src/mcp_github_pr_review/pagination.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 
 
 def encode_cursor(next_url: str) -> str:
@@ -15,7 +16,7 @@ def decode_cursor(cursor: str) -> str:
     """Decode a previously encoded cursor URL."""
     try:
         decoded = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
-    except (ValueError, UnicodeDecodeError) as exc:
+    except (ValueError, UnicodeDecodeError, binascii.Error) as exc:
         raise ValueError("Invalid pagination cursor") from exc
     if not decoded.startswith("http://") and not decoded.startswith("https://"):
         raise ValueError("Invalid pagination cursor")

--- a/src/mcp_github_pr_review/pagination.py
+++ b/src/mcp_github_pr_review/pagination.py
@@ -1,0 +1,22 @@
+"""Cursor helpers for paginated MCP tool responses."""
+
+from __future__ import annotations
+
+import base64
+
+
+def encode_cursor(next_url: str) -> str:
+    """Encode a URL cursor into a compact transport-safe string."""
+    cursor = base64.urlsafe_b64encode(next_url.encode("utf-8"))
+    return cursor.decode("ascii")
+
+
+def decode_cursor(cursor: str) -> str:
+    """Decode a previously encoded cursor URL."""
+    try:
+        decoded = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ValueError("Invalid pagination cursor") from exc
+    if not decoded.startswith("http://") and not decoded.startswith("https://"):
+        raise ValueError("Invalid pagination cursor")
+    return decoded

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -13,7 +13,7 @@ import traceback
 from collections.abc import Awaitable, Callable, Sequence
 from importlib.metadata import version
 from typing import Any, TypeVar, cast
-from urllib.parse import quote
+from urllib.parse import quote, unquote, urlparse
 
 import httpx
 from dotenv import load_dotenv
@@ -51,6 +51,7 @@ from .models import (
     PaginatedReviewCommentsResult,
     ResolveOpenPrUrlArgs,
     ReviewCommentModel,
+    ToolErrorCode,
     ToolErrorDetailsModel,
     ToolErrorEnvelopeModel,
 )
@@ -964,6 +965,26 @@ def _extract_next_link(link_header: str | None) -> str | None:
     return match.group(1) if match else None
 
 
+def _extract_cursor_pr_context(
+    cursor: str,
+) -> tuple[str | None, str | None, str | None, int | None]:
+    """Best-effort extraction of host/owner/repo/pull context from a cursor URL."""
+    try:
+        cursor_url = decode_cursor(cursor)
+    except ValueError:
+        return None, None, None, None
+
+    parsed = urlparse(cursor_url)
+    match = re.match(r"^/repos/([^/]+)/([^/]+)/pulls/(\d+)/comments$", parsed.path)
+    if not match:
+        return parsed.netloc or None, None, None, None
+
+    owner = unquote(match.group(1))
+    repo = unquote(match.group(2))
+    pull_number = int(match.group(3))
+    return parsed.netloc or None, owner, repo, pull_number
+
+
 async def fetch_pr_comments_page(
     owner: str,
     repo: str,
@@ -1432,11 +1453,11 @@ class PRReviewServer:
         """
 
         def _error_tuple(
-            code: str, message: str, next_steps: list[str]
+            code: ToolErrorCode, message: str, next_steps: list[str]
         ) -> tuple[list[TextContent], dict[str, Any]]:
             envelope = ToolErrorEnvelopeModel(
                 error=ToolErrorDetailsModel(
-                    code=code,  # type: ignore[arg-type]
+                    code=code,
                     message=message,
                     next_steps=next_steps,
                 )
@@ -1841,7 +1862,27 @@ class PRReviewServer:
         path_prefix: str | None = None,
         include_resolved: bool | None = None,
     ) -> PaginatedReviewCommentsResult:
-        """List one page of PR review comments with cursor-based pagination."""
+        """List filtered PR review comments with bounded cursor-based pagination."""
+
+        def _matches_filters(comment: CommentResult) -> bool:
+            if include_resolved is not None:
+                is_resolved = comment.get("is_resolved", False)
+                if bool(is_resolved) is not include_resolved:
+                    return False
+
+            if author:
+                user_data = comment.get("user")
+                login = user_data.get("login") if isinstance(user_data, dict) else None
+                if login != author:
+                    return False
+
+            if path_prefix:
+                path = str(comment.get("path", ""))
+                if not path.startswith(path_prefix):
+                    return False
+
+            return True
+
         resolved_url = pr_url
         request_owner = owner
         request_repo = repo
@@ -1919,54 +1960,77 @@ class PRReviewServer:
                     ],
                 ) from exc
 
-        try:
-            comments, next_cursor = await fetch_pr_comments_page(
-                owner=request_owner or "placeholder-owner",
-                repo=request_repo or "placeholder-repo",
-                pull_number=pull_number or 0,
-                host=request_host or "github.com",
-                limit=limit,
-                cursor=cursor,
-            )
-        except ToolExecutionError:
-            raise
-        except (ValueError, RuntimeError) as exc:
-            raise ToolExecutionError(
-                code="internal_error",
-                message="Unexpected failure while listing review comments.",
-                next_steps=[
-                    "Retry the request.",
-                    "Check server logs if the error persists.",
-                ],
-            ) from exc
+        if cursor and (
+            not request_owner
+            or not request_repo
+            or pull_number is None
+            or not request_host
+        ):
+            (
+                cursor_host,
+                cursor_owner,
+                cursor_repo,
+                cursor_pull_number,
+            ) = _extract_cursor_pr_context(cursor)
+            request_host = request_host or cursor_host
+            request_owner = request_owner or cursor_owner
+            request_repo = request_repo or cursor_repo
+            pull_number = pull_number if pull_number is not None else cursor_pull_number
 
-        filtered_comments: list[CommentResult] = []
-        for comment in comments:
-            if include_resolved is not None:
-                is_resolved = comment.get("is_resolved", False)
-                if bool(is_resolved) is not include_resolved:
-                    continue
+        accumulated_comments: list[CommentResult] = []
+        next_cursor: str | None = cursor
+        current_cursor = cursor
+        pages_fetched = 0
+        max_fetch_pages = _int_conf("PR_FETCH_MAX_PAGES", 50, 1, 200, None)
 
-            if author:
-                user_data = comment.get("user")
-                login = user_data.get("login") if isinstance(user_data, dict) else None
-                if login != author:
-                    continue
+        while len(accumulated_comments) < limit and pages_fetched < max_fetch_pages:
+            try:
+                comments, page_next_cursor = await fetch_pr_comments_page(
+                    owner=request_owner or "",
+                    repo=request_repo or "",
+                    pull_number=pull_number or 0,
+                    host=request_host or "github.com",
+                    limit=limit,
+                    cursor=current_cursor,
+                )
+            except ToolExecutionError:
+                raise
+            except (ValueError, RuntimeError) as exc:
+                raise ToolExecutionError(
+                    code="internal_error",
+                    message="Unexpected failure while listing review comments.",
+                    next_steps=[
+                        "Retry the request.",
+                        "Check server logs if the error persists.",
+                    ],
+                ) from exc
 
-            if path_prefix:
-                path = str(comment.get("path", ""))
-                if not path.startswith(path_prefix):
-                    continue
+            pages_fetched += 1
+            next_cursor = page_next_cursor
 
-            filtered_comments.append(comment)
+            for comment in comments:
+                if _matches_filters(comment):
+                    accumulated_comments.append(comment)
+                    if len(accumulated_comments) >= limit:
+                        break
+
+            if len(accumulated_comments) >= limit:
+                break
+            if not page_next_cursor:
+                break
+
+            current_cursor = page_next_cursor
 
         structured_items = [
-            ReviewCommentModel.model_validate(comment) for comment in filtered_comments
+            ReviewCommentModel.model_validate(comment)
+            for comment in accumulated_comments[:limit]
         ]
+        # `total` is exact only once pagination is exhausted for this query.
+        total: int | None = len(structured_items) if next_cursor is None else None
         return PaginatedReviewCommentsResult(
             items=structured_items,
             next_cursor=next_cursor,
-            total=len(structured_items),
+            total=total,
         )
 
     async def run(self) -> None:

--- a/src/mcp_github_pr_review/server.py
+++ b/src/mcp_github_pr_review/server.py
@@ -12,20 +12,27 @@ import time
 import traceback
 from collections.abc import Awaitable, Callable, Sequence
 from importlib.metadata import version
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 from urllib.parse import quote
 
 import httpx
 from dotenv import load_dotenv
 from mcp import server
-from mcp.server.lowlevel.server import NotificationOptions
+from mcp.server.lowlevel.server import (
+    CombinationContent,
+    NotificationOptions,
+    StructuredContent,
+    UnstructuredContent,
+)
 from mcp.server.models import InitializationOptions
 from mcp.types import (
     TextContent,
     Tool,
+    ToolAnnotations,
 )
 from pydantic import ValidationError
 
+from .errors import ToolExecutionError
 from .git_pr_resolver import (
     api_base_for_host,
     git_detect_repo_branch,
@@ -39,9 +46,15 @@ from .github_api_constants import (
 )
 from .models import (
     FetchPRReviewCommentsArgs,
+    GithubListPrReviewCommentsArgs,
+    GithubResolveOpenPrUrlResult,
+    PaginatedReviewCommentsResult,
     ResolveOpenPrUrlArgs,
     ReviewCommentModel,
+    ToolErrorDetailsModel,
+    ToolErrorEnvelopeModel,
 )
+from .pagination import decode_cursor, encode_cursor
 
 # Load environment variables
 load_dotenv()
@@ -886,16 +899,15 @@ async def fetch_pr_comments(
                 page_count += 1
 
                 # Enforce safety bounds to prevent unbounded memory/time use
-                print(
-                    "DEBUG: page_count="
-                    f"{page_count}, MAX_PAGES={max_pages_v}, "
-                    f"comments_len={len(all_comments)}",
-                    file=sys.stderr,
-                )
                 if page_count >= max_pages_v or len(all_comments) >= max_comments_v:
-                    print(
+                    logger.info(
                         "Reached safety limits for pagination; stopping early",
-                        file=sys.stderr,
+                        extra={
+                            "page_count": page_count,
+                            "max_pages": max_pages_v,
+                            "fetched_comments": len(all_comments),
+                            "max_comments": max_comments_v,
+                        },
                     )
                     break
 
@@ -942,6 +954,181 @@ async def fetch_pr_comments(
         )
         traceback.print_exc(file=sys.stderr)
         raise
+
+
+def _extract_next_link(link_header: str | None) -> str | None:
+    """Extract the pagination URL for rel=next from an HTTP Link header."""
+    if not link_header:
+        return None
+    match = re.search(r"<([^>]+)>;\s*rel=\"next\"", link_header)
+    return match.group(1) if match else None
+
+
+async def fetch_pr_comments_page(
+    owner: str,
+    repo: str,
+    pull_number: int,
+    *,
+    host: str = "github.com",
+    limit: int = 50,
+    cursor: str | None = None,
+    max_retries: int | None = None,
+) -> tuple[list[CommentResult], str | None]:
+    """Fetch exactly one REST page of PR comments and return a next cursor."""
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise ToolExecutionError(
+            code="auth",
+            message="GitHub authentication is required to list review comments.",
+            next_steps=[
+                "Set GITHUB_TOKEN in the environment.",
+                "Ensure the token has Pull Requests read access.",
+            ],
+        )
+
+    headers: dict[str, str] = {
+        "Accept": GITHUB_ACCEPT_HEADER,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "User-Agent": GITHUB_USER_AGENT,
+        "Authorization": f"Bearer {token}",
+    }
+    per_page = _int_conf("HTTP_PER_PAGE", 100, 1, 100, limit)
+    max_retries_v = _int_conf("HTTP_MAX_RETRIES", 3, 0, 10, max_retries)
+
+    if cursor:
+        try:
+            url = decode_cursor(cursor)
+        except ValueError as exc:
+            raise ToolExecutionError(
+                code="invalid_arguments",
+                message="The provided cursor is invalid.",
+                next_steps=[
+                    "Use the nextCursor value returned by a previous response.",
+                    "Restart pagination with cursor omitted.",
+                ],
+            ) from exc
+    else:
+        safe_owner = quote(owner, safe="")
+        safe_repo = quote(repo, safe="")
+        api_base = api_base_for_host(host)
+        url = (
+            f"{api_base}/repos/{safe_owner}/{safe_repo}/pulls/{pull_number}"
+            f"/comments?per_page={per_page}"
+        )
+
+    total_timeout = _float_conf("HTTP_TIMEOUT", 30.0, TIMEOUT_MIN, TIMEOUT_MAX)
+    connect_timeout = _float_conf(
+        "HTTP_CONNECT_TIMEOUT", 10.0, CONNECT_TIMEOUT_MIN, CONNECT_TIMEOUT_MAX
+    )
+
+    try:
+        timeout = httpx.Timeout(timeout=total_timeout, connect=connect_timeout)
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            rate_limit_handler = RateLimitHandler("fetch_pr_comments_page")
+            used_token_fallback = False
+
+            async def handle_rest_status(
+                resp: httpx.Response, _attempt: int
+            ) -> str | None:
+                nonlocal used_token_fallback
+                if (
+                    resp.status_code == 401
+                    and not used_token_fallback
+                    and headers.get("Authorization", "").startswith("Bearer ")
+                ):
+                    headers["Authorization"] = f"token {token}"
+                    used_token_fallback = True
+                    return "retry"
+                return await rate_limit_handler.handle_rate_limit(resp)
+
+            async def make_rest_request(page_url: str = url) -> httpx.Response:
+                return await client.get(page_url, headers=headers)
+
+            try:
+                response = await _retry_http_request(
+                    make_rest_request,
+                    max_retries_v,
+                    status_handler=handle_rest_status,
+                )
+            except SecondaryRateLimitError as exc:
+                raise ToolExecutionError(
+                    code="rate_limited",
+                    message=(
+                        "GitHub rate limiting prevented the request from completing."
+                    ),
+                    next_steps=[
+                        "Wait and retry after the rate limit reset window.",
+                        "Reduce request frequency or requested page size.",
+                    ],
+                ) from exc
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                if status_code in (401, 403):
+                    raise ToolExecutionError(
+                        code="auth",
+                        message="GitHub rejected the request due to authentication.",
+                        next_steps=[
+                            "Verify GITHUB_TOKEN is valid.",
+                            "Ensure the token includes Pull Requests read access.",
+                        ],
+                    ) from exc
+                if status_code == 404:
+                    raise ToolExecutionError(
+                        code="not_found",
+                        message="The pull request could not be found.",
+                        next_steps=[
+                            "Verify the owner, repo, and pull number.",
+                            "Confirm the token has access to the repository.",
+                        ],
+                    ) from exc
+                raise ToolExecutionError(
+                    code="upstream",
+                    message=f"GitHub API request failed with status {status_code}.",
+                    next_steps=[
+                        "Retry the request.",
+                        "Check GitHub API status if failures persist.",
+                    ],
+                ) from exc
+
+            page_comments = response.json()
+            if not isinstance(page_comments, list) or not all(
+                isinstance(item, dict) for item in page_comments
+            ):
+                raise ToolExecutionError(
+                    code="upstream",
+                    message="GitHub returned an unexpected response payload.",
+                    next_steps=[
+                        "Retry the request.",
+                        "Check server logs for response parsing failures.",
+                    ],
+                )
+
+            comments: list[CommentResult] = []
+            for comment in page_comments:
+                review_comment = ReviewCommentModel.from_rest(comment)
+                comments.append(review_comment.model_dump(exclude_none=True))
+
+            next_url = _extract_next_link(response.headers.get("Link"))
+            next_cursor = encode_cursor(next_url) if next_url else None
+            return comments, next_cursor
+    except httpx.TimeoutException as exc:
+        raise ToolExecutionError(
+            code="upstream",
+            message="Timed out while requesting GitHub review comments.",
+            next_steps=[
+                "Retry with a smaller limit.",
+                "Check network connectivity to GitHub.",
+            ],
+        ) from exc
+    except httpx.RequestError as exc:
+        raise ToolExecutionError(
+            code="upstream",
+            message="Network error while requesting GitHub review comments.",
+            next_steps=[
+                "Retry the request.",
+                "Check network connectivity and proxy settings.",
+            ],
+        ) from exc
 
 
 def generate_markdown(comments: Sequence[CommentResult]) -> str:
@@ -1025,6 +1212,7 @@ def generate_markdown(comments: Sequence[CommentResult]) -> str:
 
 
 T = TypeVar("T")
+ToolCallResult = UnstructuredContent | StructuredContent | CombinationContent
 
 
 class PRReviewServer:
@@ -1048,6 +1236,25 @@ class PRReviewServer:
         Each tool is defined as a Tool object containing name, description,
         and parameters.
         """
+        read_only_annotations = ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+        paginated_or_error_schema: dict[str, Any] = {
+            "oneOf": [
+                PaginatedReviewCommentsResult.model_json_schema(),
+                ToolErrorEnvelopeModel.model_json_schema(),
+            ]
+        }
+        resolve_or_error_schema: dict[str, Any] = {
+            "oneOf": [
+                GithubResolveOpenPrUrlResult.model_json_schema(),
+                ToolErrorEnvelopeModel.model_json_schema(),
+            ]
+        }
+
         return [
             Tool(
                 name="fetch_pr_review_comments",
@@ -1060,6 +1267,7 @@ class PRReviewServer:
                 ),
                 inputSchema={
                     "type": "object",
+                    "additionalProperties": False,
                     "properties": {
                         "pr_url": {
                             "type": "string",
@@ -1128,6 +1336,7 @@ class PRReviewServer:
                         },
                     },
                 },
+                annotations=read_only_annotations,
             ),
             Tool(
                 name="resolve_open_pr_url",
@@ -1141,6 +1350,7 @@ class PRReviewServer:
                 ),
                 inputSchema={
                     "type": "object",
+                    "additionalProperties": False,
                     "properties": {
                         "select_strategy": {
                             "type": "string",
@@ -1171,12 +1381,33 @@ class PRReviewServer:
                         },
                     },
                 },
+                annotations=read_only_annotations,
+            ),
+            Tool(
+                name="github_list_pr_review_comments",
+                description=(
+                    "Lists pull request review comments and returns a paginated "
+                    "review comment result."
+                ),
+                inputSchema=GithubListPrReviewCommentsArgs.model_json_schema(),
+                outputSchema=paginated_or_error_schema,
+                annotations=read_only_annotations,
+            ),
+            Tool(
+                name="github_resolve_open_pr_url",
+                description=(
+                    "Resolves an open pull request URL and returns a structured URL "
+                    "result."
+                ),
+                inputSchema=ResolveOpenPrUrlArgs.model_json_schema(),
+                outputSchema=resolve_or_error_schema,
+                annotations=read_only_annotations,
             ),
         ]
 
     async def handle_call_tool(
         self, name: str, arguments: dict[str, Any]
-    ) -> Sequence[TextContent]:
+    ) -> ToolCallResult:
         """
         Dispatch a tool invocation by name and return its textual outputs.
 
@@ -1200,6 +1431,18 @@ class PRReviewServer:
                 executing the requested tool.
         """
 
+        def _error_tuple(
+            code: str, message: str, next_steps: list[str]
+        ) -> tuple[list[TextContent], dict[str, Any]]:
+            envelope = ToolErrorEnvelopeModel(
+                error=ToolErrorDetailsModel(
+                    code=code,  # type: ignore[arg-type]
+                    message=message,
+                    next_steps=next_steps,
+                )
+            )
+            return [TextContent(type="text", text=message)], envelope.model_dump()
+
         async def _run_with_handling(operation: Callable[[], Awaitable[T]]) -> T:
             try:
                 return await operation()
@@ -1211,10 +1454,70 @@ class PRReviewServer:
                 traceback.print_exc(file=sys.stderr)
                 raise RuntimeError(error_msg) from exc
 
+        if name == "github_list_pr_review_comments":
+            try:
+                validated_args = GithubListPrReviewCommentsArgs.model_validate(
+                    arguments
+                )
+            except ValidationError as exc:
+                first_error = exc.errors()[0] if exc.errors() else None
+                if first_error:
+                    field = (
+                        first_error["loc"][0] if first_error.get("loc") else "unknown"
+                    )
+                    msg = first_error.get("msg", "Invalid value")
+                    return _error_tuple(
+                        "invalid_arguments",
+                        f"Invalid argument for {field}: {msg}",
+                        [
+                            "Check the tool input schema and fix invalid fields.",
+                            "Retry with valid argument values.",
+                        ],
+                    )
+                return _error_tuple(
+                    "invalid_arguments",
+                    "Invalid arguments.",
+                    ["Check the tool input schema and retry."],
+                )
+
+            args_dict = validated_args.model_dump(exclude_none=True)
+            try:
+                paginated_comments = await _run_with_handling(
+                    lambda: self.list_pr_review_comments(
+                        pr_url=args_dict.get("pr_url"),
+                        owner=args_dict.get("owner"),
+                        repo=args_dict.get("repo"),
+                        branch=args_dict.get("branch"),
+                        host=args_dict.get("host"),
+                        select_strategy=args_dict.get("select_strategy", "branch"),
+                        limit=args_dict.get("limit", 50),
+                        cursor=args_dict.get("cursor"),
+                        author=args_dict.get("author"),
+                        path_prefix=args_dict.get("path_prefix"),
+                        include_resolved=args_dict.get("include_resolved"),
+                    )
+                )
+            except ToolExecutionError as exc:
+                return _error_tuple(
+                    exc.code,
+                    exc.message,
+                    exc.next_steps,
+                )
+
+            summary = f"Fetched {len(paginated_comments.items)} review comment(s)."
+            if paginated_comments.next_cursor:
+                summary += " Use nextCursor to fetch the next page."
+            return (
+                [TextContent(type="text", text=summary)],
+                paginated_comments.model_dump(exclude_none=True, by_alias=True),
+            )
+
         if name == "fetch_pr_review_comments":
             # Validate arguments using Pydantic model
             try:
-                validated_args = FetchPRReviewCommentsArgs.model_validate(arguments)
+                validated_fetch_args = FetchPRReviewCommentsArgs.model_validate(
+                    arguments
+                )
             except ValidationError as e:
                 # Transform Pydantic validation errors to ValueError
                 errors = e.errors()
@@ -1297,7 +1600,7 @@ class PRReviewServer:
                 raise ValueError("Invalid arguments") from None
 
             # Extract validated arguments
-            args_dict = validated_args.model_dump(exclude_none=True)
+            args_dict = validated_fetch_args.model_dump(exclude_none=True)
 
             comments = await _run_with_handling(
                 lambda: self.fetch_pr_review_comments(
@@ -1328,7 +1631,7 @@ class PRReviewServer:
                 results.append(TextContent(type="text", text=md))
             return results
 
-        if name == "resolve_open_pr_url":
+        if name in {"resolve_open_pr_url", "github_resolve_open_pr_url"}:
             # Validate arguments using Pydantic model
             try:
                 validated_args_resolve = ResolveOpenPrUrlArgs.model_validate(arguments)
@@ -1339,7 +1642,24 @@ class PRReviewServer:
                     first_error = errors[0]
                     field = first_error["loc"][0] if first_error["loc"] else "unknown"
                     msg = first_error["msg"]
+                    if name == "github_resolve_open_pr_url":
+                        return _error_tuple(
+                            "invalid_arguments",
+                            f"Invalid value for {field}: {msg}",
+                            [
+                                (
+                                    "Check the tool input schema and retry with "
+                                    "valid values."
+                                )
+                            ],
+                        )
                     raise ValueError(f"Invalid value for {field}: {msg}") from e
+                if name == "github_resolve_open_pr_url":
+                    return _error_tuple(
+                        "invalid_arguments",
+                        "Invalid arguments.",
+                        ["Check the tool input schema and retry."],
+                    )
                 raise ValueError("Invalid arguments") from e
 
             # Extract validated arguments
@@ -1358,15 +1678,45 @@ class PRReviewServer:
                 branch = branch or ctx.branch
                 host = host or ctx.host
 
-            resolved_url = await _run_with_handling(
-                lambda: resolve_pr_url(
-                    owner=owner or "",
-                    repo=repo or "",
-                    branch=branch,
-                    select_strategy=select_strategy,
-                    host=host,
+            try:
+                resolved_url = await _run_with_handling(
+                    lambda: resolve_pr_url(
+                        owner=owner or "",
+                        repo=repo or "",
+                        branch=branch,
+                        select_strategy=select_strategy,
+                        host=host,
+                    )
                 )
-            )
+            except ValueError as exc:
+                if name == "github_resolve_open_pr_url":
+                    return _error_tuple(
+                        "not_found",
+                        str(exc),
+                        [
+                            "Verify owner/repo/branch values.",
+                            "Try select_strategy='latest' to return any open PR.",
+                        ],
+                    )
+                raise
+            except RuntimeError as exc:
+                if name == "github_resolve_open_pr_url":
+                    return _error_tuple(
+                        "upstream",
+                        str(exc),
+                        [
+                            "Retry the request.",
+                            "Verify GITHUB_TOKEN has repository read access.",
+                        ],
+                    )
+                raise
+            if name == "github_resolve_open_pr_url":
+                summary = "Resolved open pull request URL."
+                payload = GithubResolveOpenPrUrlResult(url=resolved_url)
+                return (
+                    [TextContent(type="text", text=summary)],
+                    payload.model_dump(exclude_none=True),
+                )
             return [TextContent(type="text", text=resolved_url)]
 
         raise ValueError(f"Unknown tool: {name}")
@@ -1443,7 +1793,20 @@ class PRReviewServer:
                         "branch": branch,
                     },
                 )
-                pr_url = tool_resp[0].text
+                content_blocks: UnstructuredContent
+                if isinstance(tool_resp, tuple):
+                    content_blocks = cast(UnstructuredContent, tool_resp[0])
+                elif isinstance(tool_resp, dict):
+                    raise ValueError(
+                        "Unexpected structured response for resolve_open_pr_url"
+                    )
+                else:
+                    content_blocks = tool_resp
+
+                first_block = next(iter(content_blocks), None)
+                if not isinstance(first_block, TextContent):
+                    raise ValueError("Failed to resolve PR URL from tool response")
+                pr_url = first_block.text
 
             host, owner, repo, pull_number_str = get_pr_info(pr_url)
             pull_number = int(pull_number_str)
@@ -1462,6 +1825,149 @@ class PRReviewServer:
             print(error_msg, file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
             return [{"error": error_msg}]
+
+    async def list_pr_review_comments(
+        self,
+        *,
+        pr_url: str | None = None,
+        owner: str | None = None,
+        repo: str | None = None,
+        branch: str | None = None,
+        host: str | None = None,
+        select_strategy: str = "branch",
+        limit: int = 50,
+        cursor: str | None = None,
+        author: str | None = None,
+        path_prefix: str | None = None,
+        include_resolved: bool | None = None,
+    ) -> PaginatedReviewCommentsResult:
+        """List one page of PR review comments with cursor-based pagination."""
+        resolved_url = pr_url
+        request_owner = owner
+        request_repo = repo
+        request_host = host
+        pull_number: int | None = None
+
+        if not cursor:
+            if not resolved_url:
+                if not (request_owner and request_repo and branch):
+                    try:
+                        ctx = git_detect_repo_branch()
+                    except ValueError as exc:
+                        raise ToolExecutionError(
+                            code="invalid_arguments",
+                            message=(
+                                "Unable to detect repository context for PR resolution."
+                            ),
+                            next_steps=[
+                                "Run the tool in a git repository checkout.",
+                                "Or pass owner/repo/branch explicitly.",
+                            ],
+                        ) from exc
+                    request_owner = request_owner or ctx.owner
+                    request_repo = request_repo or ctx.repo
+                    branch = branch or ctx.branch
+                    request_host = request_host or ctx.host
+                try:
+                    resolved_url = await resolve_pr_url(
+                        owner=request_owner or "",
+                        repo=request_repo or "",
+                        branch=branch,
+                        select_strategy=select_strategy,
+                        host=request_host,
+                    )
+                except ValueError as exc:
+                    raise ToolExecutionError(
+                        code="not_found",
+                        message=str(exc),
+                        next_steps=[
+                            "Verify owner/repo/branch values.",
+                            "Try select_strategy='latest' to choose any open PR.",
+                        ],
+                    ) from exc
+                except httpx.HTTPError as exc:
+                    raise ToolExecutionError(
+                        code="upstream",
+                        message="GitHub API error while resolving pull request URL.",
+                        next_steps=[
+                            "Retry the request.",
+                            "Verify GITHUB_TOKEN has repository access.",
+                        ],
+                    ) from exc
+
+            try:
+                (
+                    request_host,
+                    request_owner,
+                    request_repo,
+                    pull_number_str,
+                ) = get_pr_info(resolved_url)
+                pull_number = int(pull_number_str)
+            except ValueError as exc:
+                raise ToolExecutionError(
+                    code="invalid_arguments",
+                    message=f"Invalid pull request URL: {resolved_url}",
+                    next_steps=[
+                        (
+                            "Provide a valid URL in the format "
+                            "https://host/owner/repo/pull/123."
+                        ),
+                        (
+                            "Or omit pr_url and provide owner/repo/branch for "
+                            "auto-resolution."
+                        ),
+                    ],
+                ) from exc
+
+        try:
+            comments, next_cursor = await fetch_pr_comments_page(
+                owner=request_owner or "placeholder-owner",
+                repo=request_repo or "placeholder-repo",
+                pull_number=pull_number or 0,
+                host=request_host or "github.com",
+                limit=limit,
+                cursor=cursor,
+            )
+        except ToolExecutionError:
+            raise
+        except (ValueError, RuntimeError) as exc:
+            raise ToolExecutionError(
+                code="internal_error",
+                message="Unexpected failure while listing review comments.",
+                next_steps=[
+                    "Retry the request.",
+                    "Check server logs if the error persists.",
+                ],
+            ) from exc
+
+        filtered_comments: list[CommentResult] = []
+        for comment in comments:
+            if include_resolved is not None:
+                is_resolved = comment.get("is_resolved", False)
+                if bool(is_resolved) is not include_resolved:
+                    continue
+
+            if author:
+                user_data = comment.get("user")
+                login = user_data.get("login") if isinstance(user_data, dict) else None
+                if login != author:
+                    continue
+
+            if path_prefix:
+                path = str(comment.get("path", ""))
+                if not path.startswith(path_prefix):
+                    continue
+
+            filtered_comments.append(comment)
+
+        structured_items = [
+            ReviewCommentModel.model_validate(comment) for comment in filtered_comments
+        ]
+        return PaginatedReviewCommentsResult(
+            items=structured_items,
+            next_cursor=next_cursor,
+            total=len(structured_items),
+        )
 
     async def run(self) -> None:
         """Start the MCP server over stdio."""

--- a/tests/test_mcp_arch_review.py
+++ b/tests/test_mcp_arch_review.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, NoReturn
 from unittest.mock import AsyncMock
 
 import pytest
@@ -126,7 +126,7 @@ async def test_github_list_pr_review_comments_returns_normalized_tool_error(
     monkeypatch: pytest.MonkeyPatch,
     mcp_server: PRReviewServer,
 ) -> None:
-    async def fail(*args: Any, **kwargs: Any) -> PaginatedReviewCommentsResult:  # noqa: ARG001
+    async def fail(*args: Any, **kwargs: Any) -> NoReturn:  # noqa: ARG001
         raise ToolExecutionError(
             code="auth",
             message="Authentication failed.",
@@ -145,3 +145,116 @@ async def test_github_list_pr_review_comments_returns_normalized_tool_error(
     assert content[0].text == "Authentication failed."
     assert structured["error"]["code"] == "auth"
     assert structured["error"]["next_steps"] == ["Set GITHUB_TOKEN and retry."]
+
+
+@pytest.mark.asyncio
+async def test_list_pr_review_comments_accumulates_filtered_items_across_pages(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    first_cursor = "cursor-1"
+    fetch_calls: list[str | None] = []
+
+    async def fake_fetch(
+        *,
+        owner: str,
+        repo: str,
+        pull_number: int,
+        host: str,
+        limit: int,
+        cursor: str | None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        fetch_calls.append(cursor)
+        assert owner == "o"
+        assert repo == "r"
+        assert pull_number == 1
+        assert host == "github.com"
+        assert limit == 2
+        if cursor is None:
+            return (
+                [
+                    {"user": {"login": "other"}, "path": "src/a.py", "body": "x"},
+                    {"user": {"login": "alice"}, "path": "src/a.py", "body": "y"},
+                ],
+                first_cursor,
+            )
+        assert cursor == first_cursor
+        return (
+            [
+                {"user": {"login": "alice"}, "path": "src/b.py", "body": "z"},
+                {"user": {"login": "bob"}, "path": "src/c.py", "body": "k"},
+            ],
+            None,
+        )
+
+    monkeypatch.setattr(
+        "mcp_github_pr_review.server.fetch_pr_comments_page", fake_fetch
+    )
+
+    result = await mcp_server.list_pr_review_comments(
+        pr_url="https://github.com/o/r/pull/1",
+        limit=2,
+        author="alice",
+    )
+
+    assert fetch_calls == [None, first_cursor]
+    assert len(result.items) == 2
+    assert result.items[0].user.login == "alice"
+    assert result.items[1].user.login == "alice"
+    assert result.next_cursor is None
+    assert result.total == 2
+
+
+@pytest.mark.asyncio
+async def test_list_pr_review_comments_uses_cursor_context_without_placeholders(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    observed_kwargs: dict[str, Any] = {}
+
+    async def fake_fetch(
+        *,
+        owner: str,
+        repo: str,
+        pull_number: int,
+        host: str,
+        limit: int,
+        cursor: str | None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        observed_kwargs.update(
+            {
+                "owner": owner,
+                "repo": repo,
+                "pull_number": pull_number,
+                "host": host,
+                "limit": limit,
+                "cursor": cursor,
+            }
+        )
+        return (
+            [
+                {"user": {"login": "alice"}, "path": "src/a.py", "body": "x"},
+            ],
+            "next-cursor",
+        )
+
+    monkeypatch.setattr(
+        "mcp_github_pr_review.server.fetch_pr_comments_page", fake_fetch
+    )
+    monkeypatch.setattr(
+        "mcp_github_pr_review.server._extract_cursor_pr_context",
+        lambda _cursor: ("github.com", "owner-from-cursor", "repo-from-cursor", 99),
+    )
+
+    result = await mcp_server.list_pr_review_comments(
+        cursor="opaque-cursor",
+        limit=1,
+    )
+
+    assert observed_kwargs["owner"] == "owner-from-cursor"
+    assert observed_kwargs["repo"] == "repo-from-cursor"
+    assert observed_kwargs["pull_number"] == 99
+    assert observed_kwargs["host"] == "github.com"
+    assert observed_kwargs["cursor"] == "opaque-cursor"
+    assert result.next_cursor == "next-cursor"
+    assert result.total is None

--- a/tests/test_mcp_arch_review.py
+++ b/tests/test_mcp_arch_review.py
@@ -1,0 +1,147 @@
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_github_pr_review.errors import ToolExecutionError
+from mcp_github_pr_review.models import (
+    PaginatedReviewCommentsResult,
+    ReviewCommentModel,
+)
+from mcp_github_pr_review.server import PRReviewServer
+
+
+@pytest.mark.asyncio
+async def test_handle_list_tools_includes_canonical_arch_review_tools(
+    mcp_server: PRReviewServer,
+) -> None:
+    tools = await mcp_server.handle_list_tools()
+    tools_by_name = {tool.name: tool for tool in tools}
+
+    assert "github_list_pr_review_comments" in tools_by_name
+    assert "github_resolve_open_pr_url" in tools_by_name
+
+    list_tool = tools_by_name["github_list_pr_review_comments"]
+    assert list_tool.annotations is not None
+    assert list_tool.annotations.readOnlyHint is True
+    assert list_tool.annotations.destructiveHint is False
+    assert list_tool.annotations.idempotentHint is True
+    assert list_tool.annotations.openWorldHint is True
+    assert list_tool.outputSchema is not None
+    assert "oneOf" in list_tool.outputSchema
+    assert list_tool.inputSchema.get("additionalProperties") is False
+
+
+@pytest.mark.asyncio
+async def test_github_resolve_open_pr_url_returns_structured_output(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    resolve_mock = AsyncMock(return_value="https://github.com/o/r/pull/12")
+    monkeypatch.setattr("mcp_github_pr_review.server.resolve_pr_url", resolve_mock)
+
+    result = await mcp_server.handle_call_tool(
+        "github_resolve_open_pr_url",
+        {"owner": "o", "repo": "r", "branch": "feature"},
+    )
+
+    assert isinstance(result, tuple)
+    content, structured = result
+    assert content[0].type == "text"
+    assert "Resolved open pull request URL" in content[0].text
+    assert structured["url"] == "https://github.com/o/r/pull/12"
+
+
+@pytest.mark.asyncio
+async def test_github_list_pr_review_comments_returns_structured_output(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    paginated = PaginatedReviewCommentsResult(
+        items=[
+            ReviewCommentModel(
+                user={"login": "alice"},
+                path="src/app.py",
+                line=42,
+                body="Looks good",
+            )
+        ],
+        nextCursor="cursor-token",
+        total=1,
+    )
+    list_mock = AsyncMock(return_value=paginated)
+    monkeypatch.setattr(mcp_server, "list_pr_review_comments", list_mock)
+
+    result = await mcp_server.handle_call_tool(
+        "github_list_pr_review_comments",
+        {"pr_url": "https://github.com/o/r/pull/1", "limit": 10},
+    )
+
+    assert isinstance(result, tuple)
+    content, structured = result
+    assert content[0].type == "text"
+    assert "Fetched 1 review comment" in content[0].text
+    assert structured["total"] == 1
+    assert structured["nextCursor"] == "cursor-token"
+    assert len(structured["items"]) == 1
+
+    kwargs = list_mock.await_args.kwargs
+    assert kwargs["limit"] == 10
+    assert kwargs["pr_url"] == "https://github.com/o/r/pull/1"
+
+
+@pytest.mark.asyncio
+async def test_github_list_pr_review_comments_returns_normalized_validation_error(
+    mcp_server: PRReviewServer,
+) -> None:
+    result = await mcp_server.handle_call_tool(
+        "github_list_pr_review_comments",
+        {"limit": 0},
+    )
+
+    assert isinstance(result, tuple)
+    content, structured = result
+    assert content[0].type == "text"
+    assert "Invalid argument" in content[0].text
+    assert structured["error"]["code"] == "invalid_arguments"
+    assert structured["error"]["next_steps"]
+
+
+@pytest.mark.asyncio
+async def test_github_list_pr_review_comments_rejects_unknown_fields(
+    mcp_server: PRReviewServer,
+) -> None:
+    result = await mcp_server.handle_call_tool(
+        "github_list_pr_review_comments",
+        {"unexpectedField": "x"},
+    )
+
+    assert isinstance(result, tuple)
+    _, structured = result
+    assert structured["error"]["code"] == "invalid_arguments"
+
+
+@pytest.mark.asyncio
+async def test_github_list_pr_review_comments_returns_normalized_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_server: PRReviewServer,
+) -> None:
+    async def fail(*args: Any, **kwargs: Any) -> PaginatedReviewCommentsResult:  # noqa: ARG001
+        raise ToolExecutionError(
+            code="auth",
+            message="Authentication failed.",
+            next_steps=["Set GITHUB_TOKEN and retry."],
+        )
+
+    monkeypatch.setattr(mcp_server, "list_pr_review_comments", fail)
+
+    result = await mcp_server.handle_call_tool(
+        "github_list_pr_review_comments",
+        {"pr_url": "https://github.com/o/r/pull/1"},
+    )
+
+    assert isinstance(result, tuple)
+    content, structured = result
+    assert content[0].text == "Authentication failed."
+    assert structured["error"]["code"] == "auth"
+    assert structured["error"]["next_steps"] == ["Set GITHUB_TOKEN and retry."]


### PR DESCRIPTION
Implements the MCP architecture review spec by adding canonical read-only MCP tools with strict schemas, annotations, structured outputs, and normalized actionable error envelopes while preserving legacy tool compatibility.
The server now supports cursor-based single-page comment listing (`github_list_pr_review_comments`) and structured PR URL resolution (`github_resolve_open_pr_url`), backed by new pagination and error helper modules.
The changes also add strict Pydantic models for tool I/O, list response envelope fields (`items`, `nextCursor`, `total`), and filtering support (`author`, `path_prefix`, `include_resolved`).
Coverage includes a new contract-focused test suite plus full quality validation (`ruff format`, `ruff check --fix`, `mypy`, `compile-check`, `pytest`) passing in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List and filter PR review comments with cursor-based pagination
  * Resolve open GitHub PR URLs via a new tool
  * Improved structured error responses with actionable next steps

* **Documentation**
  * Added a comprehensive MCP architecture verification plan

* **Tests**
  * Added integration tests covering the new tools and architecture verification workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->